### PR TITLE
Issue #741 fix VPS approval continuation

### DIFF
--- a/.vtdd/pr-body-issue-741-vps-approval-continuation-candidate.md
+++ b/.vtdd/pr-body-issue-741-vps-approval-continuation-candidate.md
@@ -1,0 +1,123 @@
+## This PR satisfies Intent
+
+Issue #741 の passkey 承認後 VPS helper queue continuation が `unknown` で止まる blocker を直します。owner が VPS runner admin operator で承認したあと、Worker は `approvalGrantId` と `vpsProposalId` を根拠に continuation intent として扱い、queue handoff へ進めます。queue handoff が blocked の場合も、operator に `unknown` ではなく blocked reason / runtime truth を返します。
+
+## Satisfied Success Criteria
+
+- [x] passkey 承認後 continuation payload が本文の自然文検出に依存せず VPS maintenance flow に入る。
+- [x] queue handoff が blocked の場合でも `execution.status=blocked` と原因が response に残る。
+- [x] ordinary Dashboard Butler chat は approval/proposal ID が無ければ従来通り helper queue に入らない。
+- [x] continuation context は stored proposal の repository / Issue / dashboardThreadId と一致しない場合に拒否される。
+
+## Unsatisfied Success Criteria
+
+- VPS live systemd timer install / enable はこのPRでは未実施です。
+- bridge restart / heartbeat / watchdog self-heal の live E2E はこのPRでは未実施です。
+- VPS privileged helper sudoers 実行可能性は未確認/blocked のままです。
+
+## Non-goal violations
+
+None.
+
+## 開発前作戦図
+
+- 作戦図 evidence: `docs/development-strategy/issue-741-vps-approval-continuation.md`
+- 完了体験: Owner / Dashboard Butler が passkey 承認後に `unknown` ではなく queue 成功または明示的 blocked reason を読める。
+- VTDD 全体で進める部分: Issue #741 の live bridge recovery 検証前に、承認後 continuation routing を修復する。
+- 設計: Dashboard Butler 経路の境界として、`vpsProposalId` と `approvalGrantId` に加えて repository / Issue / dashboardThreadId を stored proposal と照合してから approval continuation intent として扱う。
+- 仮説: 画像の `unknown` の原因は、HTTP 202 だが `execution` が `null` だったため発生した。
+- 検証計画: Worker unit regression、generated worker check、full `npm test`。
+- 改修見積もり: `src/worker/runtime.js` の intent 判定・context 照合・blocked visibility、`test/worker.test.js` の regression、`worker.js` generated bundle。
+- 既に通っている経路: proposal 作成と operator URL 発行は live で成功済み。
+- 未確認の境界: VPS helper sudoers、timer install、live restart E2E。
+- 穴が出そうな箇所: blocked execution を広く返しすぎると app-server pass-through を壊すため、approval continuation に限定。
+- PR 前に確認すること: #824 merged 後の fresh branch であること、owner-specific secret を追加しないこと。
+- 実装候補と捨てた案: 固定文言追加ではなく ID payload を authoritative intent にする。mac Codex 直接 restart で終わらせる案は捨てた。
+- merge 後に通す E2E: live E2E として operator を再発行し、queue success または明示 blocked reason を検証する。
+- 次の PR を増やさない理由: routing と error visibility は同一 blocker で分割すると `unknown` が残る。
+- 停止条件: live VPS systemd 変更は passkey approval なしでは実行しない。
+
+## Dry-run Impact Report
+
+- Target Issue: #741
+- Implementing Success Criteria: passkey approval continuation routing / blocked reason visibility
+- Explicit Non-goals: deploy、credential mutation、permission mutation、VPS systemd timer install、live restart 実行
+- Expected touched files/routes/workflows: `/v2/dashboard/chat/messages` Worker runtime、Worker unit tests、generated `worker.js`
+- Affected Issues: #741
+- Affected PRs: follow-up to merged PR #824
+- Affected workflows: guarded checks / worker tests
+- Affected runtime/operator surfaces: passkey operator の VPS helper queue auto-continue response
+- What may break if we patch narrowly: continuation text が変わると再発するため、本文ではなく IDs と stored proposal context を intent 根拠にした。
+- Unknowns to investigate before coding: live approvalGrantId は operator page 内で作られるため、今回の failed grant は mac Codex から取得できない。
+- Validation needed: `node --test test/worker.test.js`; `npm run build:worker`; `npm test`
+- Stop condition: helper scope validation や GitHub queue comment 作成権限が欠ける場合は blocked reason を返すところまで。
+
+## Execution Queue Delta
+
+- Queue position before: Issue #741 post-merge live verification blocker
+- Preemption decision: EVIDENCE/EMERGENCY follow-up。passkey operator が owner-facing に失敗しており、live verification の前提を壊しているため先に修正。
+- Queue delta: Issue #741 continuation blocker を新規 follow-up PR で処理。active queue の他 Issue は置換しない。
+- Why this PR is next: bridge restart/watchdog verificationは承認後 continuation が動かないと Butler-first path で進められない。
+- Active Issues not downscoped: Active Issues are not downscoped; this PR is a bounded #741 blocker fix only.
+
+## File / Line Hypotheses
+
+- file: `src/worker/runtime.js`
+  - hypothesis: `approvalGrantId` / `vpsProposalId` 付き payload が自然文検出に依存して普通 chat へ落ちる。
+  - risk if changed narrowly: `blocked` を広く返すと app-server pass-through の既存挙動を壊す。
+  - validation: Worker regression tests。
+  - related Issue: #741
+
+## Hypothesis Retrospective
+
+- expected: ID と matching context 付き continuation は queue handoff へ進む。
+- actual: regression で `queued_for_vps_helper_execution`、blocked reason visibility、context mismatch rejection を確認。
+- mismatch: 初回修正では `blocked` を広く返しすぎ、既存 config blocker tests を壊した。
+- lesson: blocked visibility は approval continuation のみに限定する必要がある。
+- should become RAG candidate: approval continuation は本文ではなく signed payload IDs と stored proposal context を intent 根拠にする。
+
+## Verification Evidence
+
+- Unit: `node --test test/worker.test.js` pass
+- Integration: `npm test` pass: 1243 tests, 1242 pass, 1 skipped; self-parity and generated-worker checks passed
+- E2E: 未実施。merge/deploy 後に live operator continuation を再検証する。
+- Manual: live Dashboard thread では failed continuation が owner message のみ保存され、operator が `unknown` を表示することを確認。
+- Evidence path/link: `docs/development-strategy/issue-741-vps-approval-continuation.md`
+
+## Butler Completion Contract
+
+- Primary owner surface: Dashboard Butler。
+- Fallback surface: Custom GPT は明示された fallback surface として扱います。主経路ではありません。
+- Owner goal: passkey operator 承認後に VPS helper queue continuation が `unknown` で消えないこと。
+- Butler entrypoint: `/v2/dashboard/chat/messages`
+- Dashboard Butler natural-language path: Dashboard Butler の通常チャット entrypoint / 経路で、continuation では自然文に依存せず `approvalGrantId` / `vpsProposalId` を使う。
+- Action Schema exposure: 変更なし。
+- Runtime path: Worker runtime の Dashboard chat route。
+- Runner/runtime truth: queue success または blocked execution を response に残す。
+- Authority boundary: 変更なし。新しい high-risk authority は追加しない。
+- E2E evidence: 未実施。live VPS systemd 変更前の routing fix PR。
+- Completion status: incomplete
+
+## Surface Update Checklist
+
+- Cloudflare deploy: merge 後に別途必要。
+- Custom GPT Action Schema update: 不要。
+- Custom GPT Instructions update: 不要。
+- iPhone Butler live E2E: 未実施。merge/deploy 後に passkey operator で再検証する。
+
+## Related Constitution Rules
+
+- High-risk actions require scoped passkey approval.
+- Butler Completion Gate must not be claimed without live runtime evidence.
+- Do not overclaim partial adapter success.
+
+## Out-of-scope but NOT implemented
+
+- VPS systemd watchdog timer install / enable
+- bridge restart execution
+- heartbeat live verification
+- Issue #741 close
+
+## Extra changes (if any)
+
+None.

--- a/.vtdd/pr-body-issue-741-vps-approval-continuation.md
+++ b/.vtdd/pr-body-issue-741-vps-approval-continuation.md
@@ -1,0 +1,123 @@
+## This PR satisfies Intent
+
+Issue #741 の passkey 承認後 VPS helper queue continuation が `unknown` で止まる blocker を直します。owner が VPS runner admin operator で承認したあと、Worker は `approvalGrantId` と `vpsProposalId` を根拠に continuation intent として扱い、queue handoff へ進めます。queue handoff が blocked の場合も、operator に `unknown` ではなく blocked reason / runtime truth を返します。
+
+## Satisfied Success Criteria
+
+- [x] passkey 承認後 continuation payload が本文の自然文検出に依存せず VPS maintenance flow に入る。
+- [x] queue handoff が blocked の場合でも `execution.status=blocked` と原因が response に残る。
+- [x] ordinary Dashboard Butler chat は approval/proposal ID が無ければ従来通り helper queue に入らない。
+- [x] continuation context は stored proposal の repository / Issue / dashboardThreadId と一致しない場合に拒否される。
+
+## Unsatisfied Success Criteria
+
+- VPS live systemd timer install / enable はこのPRでは未実施です。
+- bridge restart / heartbeat / watchdog self-heal の live E2E はこのPRでは未実施です。
+- VPS privileged helper sudoers 実行可能性は未確認/blocked のままです。
+
+## Non-goal violations
+
+None.
+
+## 開発前作戦図
+
+- 作戦図 evidence: `docs/development-strategy/issue-741-vps-approval-continuation.md`
+- 完了体験: Owner / Dashboard Butler が passkey 承認後に `unknown` ではなく queue 成功または明示的 blocked reason を読める。
+- VTDD 全体で進める部分: Issue #741 の live bridge recovery 検証前に、承認後 continuation routing を修復する。
+- 設計: Dashboard Butler 経路の境界として、`vpsProposalId` と `approvalGrantId` に加えて repository / Issue / dashboardThreadId を stored proposal と照合してから approval continuation intent として扱う。
+- 仮説: 画像の `unknown` の原因は、HTTP 202 だが `execution` が `null` だったため発生した。
+- 検証計画: Worker unit regression、generated worker check、full `npm test`。
+- 改修見積もり: `src/worker/runtime.js` の intent 判定・context 照合・blocked visibility、`test/worker.test.js` の regression、`worker.js` generated bundle。
+- 既に通っている経路: proposal 作成と operator URL 発行は live で成功済み。
+- 未確認の境界: VPS helper sudoers、timer install、live restart E2E。
+- 穴が出そうな箇所: blocked execution を広く返しすぎると app-server pass-through を壊すため、approval continuation に限定。
+- PR 前に確認すること: #824 merged 後の fresh branch であること、owner-specific secret を追加しないこと。
+- 実装候補と捨てた案: 固定文言追加ではなく ID payload を authoritative intent にする。mac Codex 直接 restart で終わらせる案は捨てた。
+- merge 後に通す E2E: live E2E として operator を再発行し、queue success または明示 blocked reason を検証する。
+- 次の PR を増やさない理由: routing と error visibility は同一 blocker で分割すると `unknown` が残る。
+- 停止条件: live VPS systemd 変更は passkey approval なしでは実行しない。
+
+## Dry-run Impact Report
+
+- Target Issue: #741
+- Implementing Success Criteria: passkey approval continuation routing / blocked reason visibility
+- Explicit Non-goals: deploy、credential mutation、permission mutation、VPS systemd timer install、live restart 実行
+- Expected touched files/routes/workflows: `/v2/dashboard/chat/messages` Worker runtime、Worker unit tests、generated `worker.js`
+- Affected Issues: #741
+- Affected PRs: follow-up to merged PR #824
+- Affected workflows: guarded checks / worker tests
+- Affected runtime/operator surfaces: passkey operator の VPS helper queue auto-continue response
+- What may break if we patch narrowly: continuation text が変わると再発するため、本文ではなく IDs と stored proposal context を intent 根拠にした。
+- Unknowns to investigate before coding: live approvalGrantId は operator page 内で作られるため、今回の failed grant は mac Codex から取得できない。
+- Validation needed: `node --test test/worker.test.js`; `npm run build:worker`; `npm test`
+- Stop condition: helper scope validation や GitHub queue comment 作成権限が欠ける場合は blocked reason を返すところまで。
+
+## Execution Queue Delta
+
+- Queue position before: Issue #741 post-merge live verification blocker
+- Preemption decision: EVIDENCE/EMERGENCY follow-up。passkey operator が owner-facing に失敗しており、live verification の前提を壊しているため先に修正。
+- Queue delta: Issue #741 continuation blocker を新規 follow-up PR で処理。active queue の他 Issue は置換しない。
+- Why this PR is next: bridge restart/watchdog verificationは承認後 continuation が動かないと Butler-first path で進められない。
+- Active Issues not downscoped: Active Issues are not downscoped; this PR is a bounded #741 blocker fix only.
+
+## File / Line Hypotheses
+
+- file: `src/worker/runtime.js`
+  - hypothesis: `approvalGrantId` / `vpsProposalId` 付き payload が自然文検出に依存して普通 chat へ落ちる。
+  - risk if changed narrowly: `blocked` を広く返すと app-server pass-through の既存挙動を壊す。
+  - validation: Worker regression tests。
+  - related Issue: #741
+
+## Hypothesis Retrospective
+
+- expected: ID と matching context 付き continuation は queue handoff へ進む。
+- actual: regression で `queued_for_vps_helper_execution`、blocked reason visibility、context mismatch rejection を確認。
+- mismatch: 初回修正では `blocked` を広く返しすぎ、既存 config blocker tests を壊した。
+- lesson: blocked visibility は approval continuation のみに限定する必要がある。
+- should become RAG candidate: approval continuation は本文ではなく signed payload IDs と stored proposal context を intent 根拠にする。
+
+## Verification Evidence
+
+- Unit: `node --test test/worker.test.js` pass
+- Integration: `npm test` pass: 1243 tests, 1242 pass, 1 skipped; self-parity and generated-worker checks passed
+- E2E: 未実施。merge/deploy 後に live operator continuation を再検証する。
+- Manual: live Dashboard thread では failed continuation が owner message のみ保存され、operator が `unknown` を表示することを確認。
+- Evidence path/link: `docs/development-strategy/issue-741-vps-approval-continuation.md`
+
+## Butler Completion Contract
+
+- Primary owner surface: Dashboard Butler。
+- Fallback surface: Custom GPT は明示された fallback surface として扱います。主経路ではありません。
+- Owner goal: passkey operator 承認後に VPS helper queue continuation が `unknown` で消えないこと。
+- Butler entrypoint: `/v2/dashboard/chat/messages`
+- Dashboard Butler natural-language path: Dashboard Butler の通常チャット entrypoint / 経路で、continuation では自然文に依存せず `approvalGrantId` / `vpsProposalId` を使う。
+- Action Schema exposure: 変更なし。
+- Runtime path: Worker runtime の Dashboard chat route。
+- Runner/runtime truth: queue success または blocked execution を response に残す。
+- Authority boundary: 変更なし。新しい high-risk authority は追加しない。
+- E2E evidence: 未実施。live VPS systemd 変更前の routing fix PR。
+- Completion status: incomplete
+
+## Surface Update Checklist
+
+- Cloudflare deploy: merge 後に別途必要。
+- Custom GPT Action Schema update: 不要。
+- Custom GPT Instructions update: 不要。
+- iPhone Butler live E2E: 未実施。merge/deploy 後に passkey operator で再検証する。
+
+## Related Constitution Rules
+
+- High-risk actions require scoped passkey approval.
+- Butler Completion Gate must not be claimed without live runtime evidence.
+- Do not overclaim partial adapter success.
+
+## Out-of-scope but NOT implemented
+
+- VPS systemd watchdog timer install / enable
+- bridge restart execution
+- heartbeat live verification
+- Issue #741 close
+
+## Extra changes (if any)
+
+None.

--- a/docs/development-strategy/issue-741-vps-approval-continuation.md
+++ b/docs/development-strategy/issue-741-vps-approval-continuation.md
@@ -1,0 +1,83 @@
+# Issue #741 VPS approval continuation follow-up 作戦図
+
+## 完了体験
+
+Owner が VPS runner admin の passkey operator で承認したあと、operator page は Dashboard Butler に戻す continuation POST を行い、Worker は `approvalGrantId` と `vpsProposalId` を根拠に VPS helper queue handoff を継続する。失敗する場合も `unknown` ではなく、Dashboard Butler と operator response の両方に blocked reason / runtime truth が残る。
+
+## VTDD 全体で進める部分
+
+Issue #741 の bridge 自律復旧検証に入る前に、承認後 continuation が普通の chat message として吸い込まれる blocker を直す。これは VPS 実機の systemd 変更ではなく、Worker runtime の approval continuation routing 修正である。
+
+## 設計
+
+- `vpsProposalId` と `approvalGrantId` がある Dashboard chat POST は、本文の自然文検出に依存せず VPS privileged maintenance flow として扱う。
+- `blocked` になった VPS maintenance flow でも、レスポンスの `execution` を落とさず operator に原因を返す。
+- 通常の owner chat は従来通り自然文 intent 検出がある時だけ Worker-side VPS maintenance flow に入る。
+- 高リスク実行そのものは開始しない。helper queue handoff までの routing と error visibility だけを直す。
+
+## 仮説
+
+画像の `VPS helper queue handoff did not queue. unknown` は、operator page の continuation POST が HTTP 202 を受けたものの、Worker response の `execution` が `null` だったため発生した。`buildDashboardChatTurn` は text intent を検出した時だけ `buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow` を呼び、さらに `blocked` status の flow を response から落とす。承認済み continuation payload 自体を authoritative intent として扱えば、この unknown は消え、真の blocker が operator に出る。
+
+## 検証計画
+
+- Unit: passkey operator continuation text が弱くても `vpsProposalId` / `approvalGrantId` がある場合は `queued_for_vps_helper_execution` へ進む。
+- Unit: helper request が blocked の場合でも response に `execution.status=blocked` と runtime truth が残る。
+- Existing: `test/worker.test.js` の VPS maintenance / Dashboard chat 関連回帰を通す。
+- Full: `npm test` は PR 前に通す。
+- Live: merge 後、VPS で operator approval continuation を再実行し、queue comment 作成または明示的 blocked reason を確認する。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`
+  - `buildDashboardChatTurn`: approval continuation payload を natural-language intent と同等に扱う。risk は通常 chat の過検出だが、`approvalGrantId` と `vpsProposalId` の両方を要求して限定する。
+  - `shouldDashboardVpsMaintenanceFlowStayInWorker`: `blocked` も response に残す。risk は owner chat に blocked Butler message が出ることだが、VPS maintenance intent の場合は必要な runtime truth である。
+- `test/worker.test.js`
+  - continuation routing と blocked visibility の regression tests を追加する。
+
+## 既に通っている経路
+
+- `/v2/vps/privileged-maintenance/proposals` は proposal と approval operator URL を作成できた。
+- passkey operator は承認自体を完了し、continuation POST まで到達した。
+- Dashboard chat store には continuation owner message が保存された。
+
+## 未確認の境界
+
+- live VPS の privileged helper sudoers は未確認/不可であり、queue 後の root helper 実行まではこの PR で完了 claim しない。
+- 今回の修正後も live systemd timer install / enable は別途 passkey approval と runtime evidence が必要である。
+
+## 穴が出そうな箇所
+
+- `approvalGrantId` を含む payload が普通の chat として扱われると、今回と同じ unknown になる。
+- `blocked` execution を response から落とすと operator では原因が見えない。
+- continuation auth と turn build の条件がずれると、認可だけ通って実行 flow が消える。
+
+## PR 前に確認すること
+
+- #824 は merged なので、この branch から新規 PR にする。
+- PR body では #741 partial follow-up と明記し、VPS timer install / live E2E は未完了として残す。
+- owner-specific URL や secret は code / docs に追加しない。
+
+## 実装候補と捨てた案
+
+- 採用: `vpsProposalId + approvalGrantId` を continuation intent として明示判定する。
+- 採用: blocked flow も response execution に残して operator が reason を表示できるようにする。
+- 捨てた案: operator 固定文言だけを検出語に追加する。文言変更で再発するため弱い。
+- 捨てた案: mac Codex から SSH で直接 restart して終わらせる。Butler completion gate と承認後 continuation の実バグを残す。
+
+## merge 後に通す E2E
+
+- passkey operator URL を再発行し、承認後に `queued_for_vps_helper_execution` または明示的 `blocked` reason が表示されること。
+- queue が作成された場合、VPS runner/helper pickup の runtime truth を確認する。
+- bridge restart 後に heartbeat `pong_received` と PID match を確認する。
+- watchdog timer install / enable は別途 scoped approval 後に確認する。
+
+## 次の PR を増やさない理由
+
+今回の blocker は approval continuation routing と error visibility の同一原因であり、分割すると operator `unknown` が残ったままになる。systemd timer install や live self-heal test は外部副作用なので、この PR には混ぜない。
+
+## 停止条件
+
+- continuation approval scope validation が壊れている場合は、routing 修正だけで進めず scope validation の blocker を報告する。
+- GitHub App queue comment 作成権限が欠けている場合は、明示的 blocked reason を返すところまでをこの PR の完了にする。
+- live VPS systemd 変更は passkey approval なしでは実行しない。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -6135,12 +6135,16 @@ async function createVpsPrivilegedMaintenanceProposal({ payload, provider, origi
     ...approvalScope,
     vpsProposalId
   };
+  const dashboardThreadId = payload?.dashboardThreadId || payload?.dashboard_thread_id || payload?.threadId || payload?.thread_id;
+  const executionId = payload?.executionId || payload?.execution_id;
   const approvalProposalRecord = createVpsMaintenanceApprovalProposalRecord({
     vpsProposalId,
     proposal,
     approvalScope,
     expiresAt,
-    relatedIssue
+    relatedIssue,
+    dashboardThreadId,
+    executionId
   });
   if (!approvalProposalRecord.ok) {
     return {
@@ -6173,8 +6177,8 @@ async function createVpsPrivilegedMaintenanceProposal({ payload, provider, origi
     origin,
     approvalScope,
     vpsProposalId,
-    dashboardThreadId: payload?.dashboardThreadId || payload?.dashboard_thread_id || payload?.threadId || payload?.thread_id,
-    executionId: payload?.executionId || payload?.execution_id
+    dashboardThreadId,
+    executionId
   });
   const ownerAction = {
     repository: proposal.repository,
@@ -6223,7 +6227,15 @@ async function createVpsPrivilegedMaintenanceProposal({ payload, provider, origi
   };
 }
 
-function createVpsMaintenanceApprovalProposalRecord({ vpsProposalId, proposal, approvalScope, expiresAt, relatedIssue }) {
+function createVpsMaintenanceApprovalProposalRecord({
+  vpsProposalId,
+  proposal,
+  approvalScope,
+  expiresAt,
+  relatedIssue,
+  dashboardThreadId,
+  executionId
+}) {
   return createMemoryRecord({
     id: vpsProposalId,
     type: MemoryRecordType.APPROVAL_LOG,
@@ -6233,6 +6245,8 @@ function createVpsMaintenanceApprovalProposalRecord({ vpsProposalId, proposal, a
       proposal,
       approvalScope,
       relatedIssue,
+      dashboardThreadId: normalizeDashboardSingleMainChatThreadId(dashboardThreadId),
+      executionId: normalizeText(executionId),
       expiresAt
     },
     metadata: {
@@ -6358,6 +6372,37 @@ async function createVpsPrivilegedMaintenanceHelperRequest({ payload, provider }
       ok: false,
       error: "vps_privileged_maintenance_proposal_expired",
       issues: ["VPS maintenance approval proposal is expired"]
+      }
+    };
+  }
+  const requestedRepository = normalizeCanonicalRepositoryInput(
+    payload?.repository || payload?.repositoryInput || payload?.repository_input
+  );
+  const requestedIssue = normalizePositiveInteger(payload?.relatedIssue || payload?.related_issue || payload?.issueNumber);
+  const requestedThreadId = normalizeDashboardSingleMainChatThreadId(payload?.threadId || payload?.thread_id);
+  const proposalRepository = normalizeCanonicalRepositoryInput(proposalRecord.content.proposal?.repository);
+  const proposalIssue = normalizePositiveInteger(proposalRecord.content.relatedIssue);
+  const proposalThreadId = normalizeDashboardSingleMainChatThreadId(proposalRecord.content.dashboardThreadId);
+  const contextIssues = [];
+  if (requestedRepository && requestedRepository !== proposalRepository) {
+    contextIssues.push("repository does not match the VPS maintenance approval proposal");
+  }
+  if (requestedIssue && requestedIssue !== proposalIssue) {
+    contextIssues.push("relatedIssue does not match the VPS maintenance approval proposal");
+  }
+  if (requestedThreadId && proposalThreadId && requestedThreadId !== proposalThreadId) {
+    contextIssues.push("dashboardThreadId does not match the VPS maintenance approval proposal");
+  }
+  if (contextIssues.length > 0) {
+    return {
+      ok: false,
+      status: 403,
+      error: "vps_privileged_maintenance_context_mismatch",
+      issues: contextIssues,
+      body: {
+      ok: false,
+      error: "vps_privileged_maintenance_context_mismatch",
+      issues: contextIssues
       }
     };
   }
@@ -6915,7 +6960,13 @@ async function authorizeDashboardVpsApprovalContinuation({ payload, env } = {}) 
     };
   }
   const helper = await createVpsPrivilegedMaintenanceHelperRequest({
-    payload: { vpsProposalId, approvalGrantId },
+    payload: {
+      vpsProposalId,
+      approvalGrantId,
+      repository: input.repository || input.repositoryInput || input.repository_input,
+      relatedIssue: input.relatedIssue || input.related_issue || input.issueNumber,
+      threadId
+    },
     provider
   });
   if (!helper.ok) {
@@ -12702,7 +12753,14 @@ async function buildDashboardChatTurn(payload, options = {}) {
     },
     { threadId }
   );
-  const hasVpsPrivilegedMaintenanceIntent = detectDashboardVpsPrivilegedMaintenanceIntent({ text });
+  const hasVpsApprovalContinuationIntent =
+    Boolean(normalizeText(input.vpsProposalId || input.vps_proposal_id)) &&
+    Boolean(normalizeText(input.approvalGrantId || input.approval_grant_id)) &&
+    Boolean(threadId) &&
+    Boolean(repository) &&
+    Boolean(relatedIssue);
+  const hasVpsPrivilegedMaintenanceIntent =
+    hasVpsApprovalContinuationIntent || detectDashboardVpsPrivilegedMaintenanceIntent({ text });
   const vpsMaintenanceFlow = hasVpsPrivilegedMaintenanceIntent
     ? await buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
         payload: { ...input, relatedIssue, issueNumber: relatedIssue },
@@ -12712,7 +12770,9 @@ async function buildDashboardChatTurn(payload, options = {}) {
         env: options.env
       })
     : null;
-  const keepVpsMaintenanceInWorker = shouldDashboardVpsMaintenanceFlowStayInWorker(vpsMaintenanceFlow);
+  const keepVpsMaintenanceInWorker = shouldDashboardVpsMaintenanceFlowStayInWorker(vpsMaintenanceFlow, {
+    approvalContinuation: hasVpsApprovalContinuationIntent
+  });
   const butlerMessage = keepVpsMaintenanceInWorker
     ? normalizeDashboardChatMessage(
         {
@@ -12738,9 +12798,10 @@ async function buildDashboardChatTurn(payload, options = {}) {
   };
 }
 
-function shouldDashboardVpsMaintenanceFlowStayInWorker(flow = null) {
+function shouldDashboardVpsMaintenanceFlowStayInWorker(flow = null, options = {}) {
   const status = normalizeText(flow?.execution?.status || flow?.messageStatus);
-  return ["approval_required", "queued_for_vps_helper_execution", "sent"].includes(status);
+  return ["approval_required", "queued_for_vps_helper_execution", "sent"].includes(status) ||
+    (options.approvalContinuation === true && status === "blocked");
 }
 
 async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
@@ -12890,7 +12951,13 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
   const vpsProposalId = vpsProposalIdInput;
 
   const helper = await createVpsPrivilegedMaintenanceHelperRequest({
-    payload: { vpsProposalId, approvalGrantId },
+    payload: {
+      vpsProposalId,
+      approvalGrantId,
+      repository,
+      relatedIssue,
+      threadId: payload?.threadId || payload?.thread_id
+    },
     provider
   });
   if (!helper.ok) {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3445,6 +3445,257 @@ test("worker allows VPS passkey operator continuation without Cloudflare Access 
   assert.equal(queueCommentBody.includes("dashboard_bridge_unresolved_deploy_sync_restart"), true);
 });
 
+test("worker treats approvalGrantId and vpsProposalId as VPS continuation intent", async () => {
+  const store = createInMemoryDashboardChatStore();
+  const provider = createInMemoryMemoryProvider();
+  const proposalResponse = await worker.fetch(
+    new Request("https://example.com/v2/vps/privileged-maintenance/proposals", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        host: "x85-131-245-163",
+        repository: "marushu/vtdd-v2-p",
+        relatedIssue: 741,
+        operation: "enable",
+        id: "dashboard.bridge.unresolved.deploy.sync.restart",
+        title: "Deploy後 repo-less Dashboard bridge sync/restart",
+        commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+        riskLevel: "medium",
+        workingDirectories: ["/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"],
+        allowedArgs: [
+          "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main"
+        ],
+        affectedPaths: [
+          "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+          "vtdd-dashboard-app-server-bridge-unresolved.service"
+        ],
+        redactionRules: ["no secrets"],
+        rollbackPlan: "stop auto follow-up proposal",
+        expectedRuntimeTruth: ["before git HEAD", "after git HEAD", "after service active state"],
+        reason: "Issue #741 deploy follow-up",
+        impactScope: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p, vtdd-dashboard-app-server-bridge-unresolved.service",
+        dashboardThreadId: "dashboard-main-unresolved",
+        executionId: "issue741-approval-continuation-weak-text"
+      })
+    }),
+    { ...gatewayAuthEnv, MEMORY_PROVIDER: provider }
+  );
+  assert.equal(proposalResponse.status, 200);
+  const proposalBody = await proposalResponse.json();
+  await provider.store({
+    id: "approval:vps-operator-weak-text",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval:vps-operator-weak-text",
+      credentialId: "AQIDBA",
+      verifiedAt: "2026-06-07T10:00:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: proposalBody.approvalScope
+    },
+    metadata: { source: "vps-operator-weak-text-test" },
+    priority: 96,
+    tags: ["passkey_grant", "passkey_approval", "verified"],
+    createdAt: "2026-06-07T10:00:00.000Z"
+  });
+
+  const githubCalls = [];
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "dashboard-main-unresolved",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 741,
+        text: "承認済みです。",
+        vpsProposalId: proposalBody.vpsProposalId,
+        approvalGrantId: "approval:vps-operator-weak-text",
+        executionId: "issue741-approval-continuation-weak-text"
+      })
+    }),
+    {
+      DASHBOARD_CHAT_STORE: store,
+      MEMORY_PROVIDER: provider,
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p",
+      GITHUB_APP_INSTALLATION_TOKEN: "ghs_dashboard_vps",
+      GITHUB_API_FETCH: async (url, init) => {
+        githubCalls.push({ url, init });
+        return new Response(
+          JSON.stringify({
+            id: 74103,
+            html_url: "https://github.com/marushu/vtdd-v2-p/issues/741#issuecomment-74103"
+          }),
+          { status: 201, headers: { "content-type": "application/json" } }
+        );
+      }
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.status, "queued_for_vps_helper_execution");
+  assert.equal(body.execution.runtimeTruth.helperQueueReached, true);
+  assert.equal(body.messages.length, 2);
+  assert.equal(body.messages[1].status, "sent");
+  assert.equal(githubCalls.length, 1);
+});
+
+test("worker returns blocked VPS continuation execution instead of dropping it", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const proposalResponse = await worker.fetch(
+    new Request("https://example.com/v2/vps/privileged-maintenance/proposals", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        host: "x85-131-245-163",
+        repository: "marushu/vtdd-v2-p",
+        relatedIssue: 741,
+        operation: "enable",
+        id: "dashboard.bridge.unresolved.deploy.sync.restart",
+        title: "Deploy後 repo-less Dashboard bridge sync/restart",
+        commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+        riskLevel: "medium",
+        workingDirectories: ["/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"],
+        allowedArgs: [
+          "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main"
+        ],
+        rollbackPlan: "stop auto follow-up proposal",
+        reason: "Issue #741 deploy follow-up",
+        impactScope: "vtdd-dashboard-app-server-bridge-unresolved.service",
+        dashboardThreadId: "dashboard-main-unresolved",
+        executionId: "issue741-approval-continuation-blocked"
+      })
+    }),
+    { ...gatewayAuthEnv, MEMORY_PROVIDER: provider }
+  );
+  assert.equal(proposalResponse.status, 200);
+  const proposalBody = await proposalResponse.json();
+  await provider.store({
+    id: "approval:vps-operator-queue-blocked",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval:vps-operator-queue-blocked",
+      credentialId: "AQIDBA",
+      verifiedAt: "2026-06-07T10:00:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: proposalBody.approvalScope
+    },
+    metadata: { source: "vps-operator-queue-blocked-test" },
+    priority: 96,
+    tags: ["passkey_grant", "passkey_approval", "verified"],
+    createdAt: "2026-06-07T10:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/dashboard/chat/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        threadId: "dashboard-main-unresolved",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 741,
+        text: "承認済みです。",
+        vpsProposalId: proposalBody.vpsProposalId,
+        approvalGrantId: "approval:vps-operator-queue-blocked",
+        executionId: "issue741-approval-continuation-blocked"
+      })
+    }),
+    {
+      DASHBOARD_CHAT_STORE: createInMemoryDashboardChatStore(),
+      MEMORY_PROVIDER: provider,
+      VTDD_DASHBOARD_VPS_MAINTENANCE_HOST: "x85-131-245-163",
+      VTDD_DASHBOARD_VPS_MAINTENANCE_WORKDIR: "/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"
+    }
+  );
+
+  assert.equal(response.status, 202);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.execution.status, "blocked");
+  assert.equal(body.execution.vpsProposalId, proposalBody.vpsProposalId);
+  assert.equal(body.messages.length, 2);
+  assert.equal(body.messages[1].status, "blocked");
+  assert.match(body.messages[1].text, /github_write_unavailable/);
+  assert.match(body.messages[1].text, /GitHub App installation token is unavailable/);
+});
+
+test("worker rejects VPS continuation context that does not match the stored proposal", async () => {
+  const provider = createInMemoryMemoryProvider();
+  const proposalResponse = await worker.fetch(
+    new Request("https://example.com/v2/vps/privileged-maintenance/proposals", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        host: "x85-131-245-163",
+        repository: "marushu/vtdd-v2-p",
+        relatedIssue: 741,
+        operation: "enable",
+        id: "dashboard.bridge.unresolved.deploy.sync.restart",
+        title: "Deploy後 repo-less Dashboard bridge sync/restart",
+        commandClass: "dashboard_bridge_unresolved_deploy_sync_restart",
+        riskLevel: "medium",
+        workingDirectories: ["/home/vtdd-runner/vtdd-runner/repos/vtdd-v2-p"],
+        allowedArgs: [
+          "node scripts/sync-dashboard-app-server-bridge-after-deploy.mjs --service vtdd-dashboard-app-server-bridge-unresolved.service --ref origin/main"
+        ],
+        rollbackPlan: "stop auto follow-up proposal",
+        reason: "Issue #741 deploy follow-up",
+        impactScope: "vtdd-dashboard-app-server-bridge-unresolved.service",
+        dashboardThreadId: "dashboard-main-unresolved",
+        executionId: "issue741-approval-continuation-context"
+      })
+    }),
+    { ...gatewayAuthEnv, MEMORY_PROVIDER: provider }
+  );
+  assert.equal(proposalResponse.status, 200);
+  const proposalBody = await proposalResponse.json();
+  await provider.store({
+    id: "approval:vps-operator-context",
+    type: MemoryRecordType.APPROVAL_LOG,
+    content: {
+      kind: "passkey_grant",
+      status: "verified",
+      approvalId: "approval:vps-operator-context",
+      credentialId: "AQIDBA",
+      verifiedAt: "2026-06-07T10:00:00.000Z",
+      expiresAt: "2999-01-01T00:00:00.000Z",
+      scope: proposalBody.approvalScope
+    },
+    metadata: { source: "vps-operator-context-test" },
+    priority: 96,
+    tags: ["passkey_grant", "passkey_approval", "verified"],
+    createdAt: "2026-06-07T10:00:00.000Z"
+  });
+
+  const response = await worker.fetch(
+    new Request("https://example.com/v2/vps/privileged-maintenance/helper-requests", {
+      method: "POST",
+      headers: gatewayAuthHeaders,
+      body: JSON.stringify({
+        vpsProposalId: proposalBody.vpsProposalId,
+        approvalGrantId: "approval:vps-operator-context",
+        repository: "marushu/other",
+        relatedIssue: 742,
+        threadId: "dashboard-main-other"
+      })
+    }),
+    { ...gatewayAuthEnv, MEMORY_PROVIDER: provider }
+  );
+
+  assert.equal(response.status, 403);
+  const body = await response.json();
+  assert.equal(body.error, "vps_privileged_maintenance_context_mismatch");
+  assert.equal(body.issues.includes("repository does not match the VPS maintenance approval proposal"), true);
+  assert.equal(body.issues.includes("relatedIssue does not match the VPS maintenance approval proposal"), true);
+  assert.equal(body.issues.includes("dashboardThreadId does not match the VPS maintenance approval proposal"), true);
+});
+
 test("worker keeps ordinary Dashboard Butler planning chat out of VPS helper queue", async () => {
   const store = createInMemoryDashboardChatStore();
   const response = await worker.fetch(

--- a/worker.js
+++ b/worker.js
@@ -63301,12 +63301,16 @@ async function createVpsPrivilegedMaintenanceProposal({ payload, provider, origi
     ...approvalScope,
     vpsProposalId
   };
+  const dashboardThreadId = payload?.dashboardThreadId || payload?.dashboard_thread_id || payload?.threadId || payload?.thread_id;
+  const executionId = payload?.executionId || payload?.execution_id;
   const approvalProposalRecord = createVpsMaintenanceApprovalProposalRecord({
     vpsProposalId,
     proposal,
     approvalScope,
     expiresAt,
-    relatedIssue
+    relatedIssue,
+    dashboardThreadId,
+    executionId
   });
   if (!approvalProposalRecord.ok) {
     return {
@@ -63339,8 +63343,8 @@ async function createVpsPrivilegedMaintenanceProposal({ payload, provider, origi
     origin,
     approvalScope,
     vpsProposalId,
-    dashboardThreadId: payload?.dashboardThreadId || payload?.dashboard_thread_id || payload?.threadId || payload?.thread_id,
-    executionId: payload?.executionId || payload?.execution_id
+    dashboardThreadId,
+    executionId
   });
   const ownerAction = {
     repository: proposal.repository,
@@ -63387,7 +63391,15 @@ async function createVpsPrivilegedMaintenanceProposal({ payload, provider, origi
     body
   };
 }
-function createVpsMaintenanceApprovalProposalRecord({ vpsProposalId, proposal, approvalScope, expiresAt, relatedIssue }) {
+function createVpsMaintenanceApprovalProposalRecord({
+  vpsProposalId,
+  proposal,
+  approvalScope,
+  expiresAt,
+  relatedIssue,
+  dashboardThreadId,
+  executionId
+}) {
   return createMemoryRecord({
     id: vpsProposalId,
     type: MemoryRecordType.APPROVAL_LOG,
@@ -63397,6 +63409,8 @@ function createVpsMaintenanceApprovalProposalRecord({ vpsProposalId, proposal, a
       proposal,
       approvalScope,
       relatedIssue,
+      dashboardThreadId: normalizeDashboardSingleMainChatThreadId(dashboardThreadId),
+      executionId: normalizeText33(executionId),
       expiresAt
     },
     metadata: {
@@ -63516,6 +63530,37 @@ async function createVpsPrivilegedMaintenanceHelperRequest({ payload, provider }
         ok: false,
         error: "vps_privileged_maintenance_proposal_expired",
         issues: ["VPS maintenance approval proposal is expired"]
+      }
+    };
+  }
+  const requestedRepository = normalizeCanonicalRepositoryInput(
+    payload?.repository || payload?.repositoryInput || payload?.repository_input
+  );
+  const requestedIssue = normalizePositiveInteger10(payload?.relatedIssue || payload?.related_issue || payload?.issueNumber);
+  const requestedThreadId = normalizeDashboardSingleMainChatThreadId(payload?.threadId || payload?.thread_id);
+  const proposalRepository = normalizeCanonicalRepositoryInput(proposalRecord.content.proposal?.repository);
+  const proposalIssue = normalizePositiveInteger10(proposalRecord.content.relatedIssue);
+  const proposalThreadId = normalizeDashboardSingleMainChatThreadId(proposalRecord.content.dashboardThreadId);
+  const contextIssues = [];
+  if (requestedRepository && requestedRepository !== proposalRepository) {
+    contextIssues.push("repository does not match the VPS maintenance approval proposal");
+  }
+  if (requestedIssue && requestedIssue !== proposalIssue) {
+    contextIssues.push("relatedIssue does not match the VPS maintenance approval proposal");
+  }
+  if (requestedThreadId && proposalThreadId && requestedThreadId !== proposalThreadId) {
+    contextIssues.push("dashboardThreadId does not match the VPS maintenance approval proposal");
+  }
+  if (contextIssues.length > 0) {
+    return {
+      ok: false,
+      status: 403,
+      error: "vps_privileged_maintenance_context_mismatch",
+      issues: contextIssues,
+      body: {
+        ok: false,
+        error: "vps_privileged_maintenance_context_mismatch",
+        issues: contextIssues
       }
     };
   }
@@ -64033,7 +64078,13 @@ async function authorizeDashboardVpsApprovalContinuation({ payload, env } = {}) 
     };
   }
   const helper = await createVpsPrivilegedMaintenanceHelperRequest({
-    payload: { vpsProposalId, approvalGrantId },
+    payload: {
+      vpsProposalId,
+      approvalGrantId,
+      repository: input.repository || input.repositoryInput || input.repository_input,
+      relatedIssue: input.relatedIssue || input.related_issue || input.issueNumber,
+      threadId
+    },
     provider
   });
   if (!helper.ok) {
@@ -69116,7 +69167,8 @@ async function buildDashboardChatTurn(payload, options = {}) {
     },
     { threadId }
   );
-  const hasVpsPrivilegedMaintenanceIntent = detectDashboardVpsPrivilegedMaintenanceIntent({ text });
+  const hasVpsApprovalContinuationIntent = Boolean(normalizeText33(input.vpsProposalId || input.vps_proposal_id)) && Boolean(normalizeText33(input.approvalGrantId || input.approval_grant_id)) && Boolean(threadId) && Boolean(repository) && Boolean(relatedIssue);
+  const hasVpsPrivilegedMaintenanceIntent = hasVpsApprovalContinuationIntent || detectDashboardVpsPrivilegedMaintenanceIntent({ text });
   const vpsMaintenanceFlow = hasVpsPrivilegedMaintenanceIntent ? await buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
     payload: { ...input, relatedIssue, issueNumber: relatedIssue },
     repository,
@@ -69124,7 +69176,9 @@ async function buildDashboardChatTurn(payload, options = {}) {
     origin: options.origin,
     env: options.env
   }) : null;
-  const keepVpsMaintenanceInWorker = shouldDashboardVpsMaintenanceFlowStayInWorker(vpsMaintenanceFlow);
+  const keepVpsMaintenanceInWorker = shouldDashboardVpsMaintenanceFlowStayInWorker(vpsMaintenanceFlow, {
+    approvalContinuation: hasVpsApprovalContinuationIntent
+  });
   const butlerMessage = keepVpsMaintenanceInWorker ? normalizeDashboardChatMessage(
     {
       threadId,
@@ -69146,9 +69200,9 @@ async function buildDashboardChatTurn(payload, options = {}) {
     execution: keepVpsMaintenanceInWorker ? vpsMaintenanceFlow?.execution || null : null
   };
 }
-function shouldDashboardVpsMaintenanceFlowStayInWorker(flow = null) {
+function shouldDashboardVpsMaintenanceFlowStayInWorker(flow = null, options = {}) {
   const status = normalizeText33(flow?.execution?.status || flow?.messageStatus);
-  return ["approval_required", "queued_for_vps_helper_execution", "sent"].includes(status);
+  return ["approval_required", "queued_for_vps_helper_execution", "sent"].includes(status) || options.approvalContinuation === true && status === "blocked";
 }
 async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
   payload,
@@ -69293,7 +69347,13 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
   }
   const vpsProposalId = vpsProposalIdInput;
   const helper = await createVpsPrivilegedMaintenanceHelperRequest({
-    payload: { vpsProposalId, approvalGrantId },
+    payload: {
+      vpsProposalId,
+      approvalGrantId,
+      repository,
+      relatedIssue,
+      threadId: payload?.threadId || payload?.thread_id
+    },
     provider
   });
   if (!helper.ok) {


### PR DESCRIPTION
## This PR satisfies Intent

Issue #741 の passkey 承認後 VPS helper queue continuation が `unknown` で止まる blocker を直します。owner が VPS runner admin operator で承認したあと、Worker は `approvalGrantId` と `vpsProposalId` を根拠に continuation intent として扱い、queue handoff へ進めます。queue handoff が blocked の場合も、operator に `unknown` ではなく blocked reason / runtime truth を返します。

## Satisfied Success Criteria

- [x] passkey 承認後 continuation payload が本文の自然文検出に依存せず VPS maintenance flow に入る。
- [x] queue handoff が blocked の場合でも `execution.status=blocked` と原因が response に残る。
- [x] ordinary Dashboard Butler chat は approval/proposal ID が無ければ従来通り helper queue に入らない。
- [x] continuation context は stored proposal の repository / Issue / dashboardThreadId と一致しない場合に拒否される。

## Unsatisfied Success Criteria

- VPS live systemd timer install / enable はこのPRでは未実施です。
- bridge restart / heartbeat / watchdog self-heal の live E2E はこのPRでは未実施です。
- VPS privileged helper sudoers 実行可能性は未確認/blocked のままです。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-741-vps-approval-continuation.md`
- 完了体験: Owner / Dashboard Butler が passkey 承認後に `unknown` ではなく queue 成功または明示的 blocked reason を読める。
- VTDD 全体で進める部分: Issue #741 の live bridge recovery 検証前に、承認後 continuation routing を修復する。
- 設計: Dashboard Butler 経路の境界として、`vpsProposalId` と `approvalGrantId` に加えて repository / Issue / dashboardThreadId を stored proposal と照合してから approval continuation intent として扱う。
- 仮説: 画像の `unknown` の原因は、HTTP 202 だが `execution` が `null` だったため発生した。
- 検証計画: Worker unit regression、generated worker check、full `npm test`。
- 改修見積もり: `src/worker/runtime.js` の intent 判定・context 照合・blocked visibility、`test/worker.test.js` の regression、`worker.js` generated bundle。
- 既に通っている経路: proposal 作成と operator URL 発行は live で成功済み。
- 未確認の境界: VPS helper sudoers、timer install、live restart E2E。
- 穴が出そうな箇所: blocked execution を広く返しすぎると app-server pass-through を壊すため、approval continuation に限定。
- PR 前に確認すること: #824 merged 後の fresh branch であること、owner-specific secret を追加しないこと。
- 実装候補と捨てた案: 固定文言追加ではなく ID payload を authoritative intent にする。mac Codex 直接 restart で終わらせる案は捨てた。
- merge 後に通す E2E: live E2E として operator を再発行し、queue success または明示 blocked reason を検証する。
- 次の PR を増やさない理由: routing と error visibility は同一 blocker で分割すると `unknown` が残る。
- 停止条件: live VPS systemd 変更は passkey approval なしでは実行しない。

## Dry-run Impact Report

- Target Issue: #741
- Implementing Success Criteria: passkey approval continuation routing / blocked reason visibility
- Explicit Non-goals: deploy、credential mutation、permission mutation、VPS systemd timer install、live restart 実行
- Expected touched files/routes/workflows: `/v2/dashboard/chat/messages` Worker runtime、Worker unit tests、generated `worker.js`
- Affected Issues: #741
- Affected PRs: follow-up to merged PR #824
- Affected workflows: guarded checks / worker tests
- Affected runtime/operator surfaces: passkey operator の VPS helper queue auto-continue response
- What may break if we patch narrowly: continuation text が変わると再発するため、本文ではなく IDs と stored proposal context を intent 根拠にした。
- Unknowns to investigate before coding: live approvalGrantId は operator page 内で作られるため、今回の failed grant は mac Codex から取得できない。
- Validation needed: `node --test test/worker.test.js`; `npm run build:worker`; `npm test`
- Stop condition: helper scope validation や GitHub queue comment 作成権限が欠ける場合は blocked reason を返すところまで。

## Execution Queue Delta

- Queue position before: Issue #741 post-merge live verification blocker
- Preemption decision: EVIDENCE/EMERGENCY follow-up。passkey operator が owner-facing に失敗しており、live verification の前提を壊しているため先に修正。
- Queue delta: Issue #741 continuation blocker を新規 follow-up PR で処理。active queue の他 Issue は置換しない。
- Why this PR is next: bridge restart/watchdog verificationは承認後 continuation が動かないと Butler-first path で進められない。
- Active Issues not downscoped: Active Issues are not downscoped; this PR is a bounded #741 blocker fix only.

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `approvalGrantId` / `vpsProposalId` 付き payload が自然文検出に依存して普通 chat へ落ちる。
  - risk if changed narrowly: `blocked` を広く返すと app-server pass-through の既存挙動を壊す。
  - validation: Worker regression tests。
  - related Issue: #741

## Hypothesis Retrospective

- expected: ID と matching context 付き continuation は queue handoff へ進む。
- actual: regression で `queued_for_vps_helper_execution`、blocked reason visibility、context mismatch rejection を確認。
- mismatch: 初回修正では `blocked` を広く返しすぎ、既存 config blocker tests を壊した。
- lesson: blocked visibility は approval continuation のみに限定する必要がある。
- should become RAG candidate: approval continuation は本文ではなく signed payload IDs と stored proposal context を intent 根拠にする。

## Verification Evidence

- Unit: `node --test test/worker.test.js` pass
- Integration: `npm test` pass: 1243 tests, 1242 pass, 1 skipped; self-parity and generated-worker checks passed
- E2E: 未実施。merge/deploy 後に live operator continuation を再検証する。
- Manual: live Dashboard thread では failed continuation が owner message のみ保存され、operator が `unknown` を表示することを確認。
- Evidence path/link: `docs/development-strategy/issue-741-vps-approval-continuation.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は明示された fallback surface として扱います。主経路ではありません。
- Owner goal: passkey operator 承認後に VPS helper queue continuation が `unknown` で消えないこと。
- Butler entrypoint: `/v2/dashboard/chat/messages`
- Dashboard Butler natural-language path: Dashboard Butler の通常チャット entrypoint / 経路で、continuation では自然文に依存せず `approvalGrantId` / `vpsProposalId` を使う。
- Action Schema exposure: 変更なし。
- Runtime path: Worker runtime の Dashboard chat route。
- Runner/runtime truth: queue success または blocked execution を response に残す。
- Authority boundary: 変更なし。新しい high-risk authority は追加しない。
- E2E evidence: 未実施。live VPS systemd 変更前の routing fix PR。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に別途必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy 後に passkey operator で再検証する。

## Related Constitution Rules

- High-risk actions require scoped passkey approval.
- Butler Completion Gate must not be claimed without live runtime evidence.
- Do not overclaim partial adapter success.

## Out-of-scope but NOT implemented

- VPS systemd watchdog timer install / enable
- bridge restart execution
- heartbeat live verification
- Issue #741 close

## Extra changes (if any)

None.
