### PR TITLE
Issue #741 stop Issue comment helper queue

### DIFF
--- a/.vtdd/pr-body-issue-741-stop-issue-comment-helper-queue-candidate.md
+++ b/.vtdd/pr-body-issue-741-stop-issue-comment-helper-queue-candidate.md
@@ -1,0 +1,138 @@
+## This PR satisfies Intent
+
+Issue #741 の follow-up として、VPS privileged maintenance helper execution を GitHub Issue コメント queue に溜め続ける旧経路を止めます。
+
+この PR は pagination 修正ではありません。Issue コメント transport を延命せず、Dashboard Butler / passkey operator continuation は `vps_local_helper_queue_unavailable` として blocked を返し、GitHub Issue comment を作らず、root/helper execution を開始しません。
+
+## Satisfied Success Criteria
+
+- [x] Dashboard Butler / passkey operator continuation が VPS helper execution queue として GitHub Issue コメントを作らない。
+- [x] valid helper execution envelope でも、VPS local queue/state/log transport が未接続なら owner-facing に `blocked` を返す。
+- [x] blocked runtime truth に `queueCommentPosted=false`, `rootExecutionStarted=false`, `helperExecutionStarted=false`, `disabledTransport=github_issue_comment_queue`, `requiredTransport=vps_local_helper_queue` を残す。
+- [x] passkey operator は queued 以外を `unknown` にせず、blocked reason と next action を表示する。
+- [x] low-risk read/status も Issue コメント queue へ流さない。
+
+## Unsatisfied Success Criteria
+
+- VPS local queue/state/log writer / consumer はこの PR では未接続。
+- bridge restart の live 実行、before/after truth、watchdog timer install/enable は未実施。
+- 既存 Issue #741 に溜まった過去 queue コメントの cleanup は未実施。
+- Issue #741 close は未実施。
+
+## Non-goal violations
+
+None.
+
+## 開発前作戦図
+
+- 作戦図 evidence: `docs/development-strategy/issue-741-stop-issue-comment-helper-queue.md`
+- 完了体験: Issue コメントに実行依頼 JSON が溜まり続けず、未接続なら Dashboard Butler / operator に blocked reason が返る。
+- VTDD 全体で進める部分: Issue #741 / #637 / #413 / #450 を横断する Issue comment helper queue defect を止める。
+- 設計: `helper-execution-queues` は Issue comment を書かず、`vps_local_helper_queue_unavailable` blocked を返す。local queue 未接続の blocked は Worker 側 owner-facing reply として残す。
+- 仮説: 原因は pagination ではなく GitHub Issue comment transport 自体である、という仮説で実装前に検証する。
+- 検証計画: worker unit、vps-runner script unit、generated worker、full `npm test`。
+- 改修見積もり: `src/worker/runtime.js`, `src/core/passkey-operator-page.js`, `test/worker.test.js`, `test/active-issue-execution-queue.test.js`, `docs/mvp/active-issue-execution-queue.md`, `worker.js`。
+- 既に通っている経路: proposal / passkey operator URL / helper envelope generation。
+- 未確認の境界: VPS local queue format, retention, consumer service。
+- 穴が出そうな箇所: blocked flow が app-server bridge に流れる、low-risk read が旧 queue に残る、operator が unknown に戻る。
+- PR 前に確認すること: GitHub Issue comment create が呼ばれないこと、runtime truth が blocked を示すこと、root/helper execution が開始しないこと。
+- 実装候補と捨てた案: pagination 修正は旧 transport 延命なので不採用。
+- merge 後に通す E2E: E2E evidence として passkey operator live continuation を実行し、Issue コメントが増えず blocked reason が表示されることを確認する。
+- 次の PR を増やさない理由: これは safety slice。VPS local queue の full implementation は別 PR で authority / retention / E2E を扱う。
+- 停止条件: deploy、credential mutation、permission mutation、root/sudo、VPS systemd install/enable が必要になる場合。
+
+## Dry-run Impact Report
+
+- Target Issue: #741
+- Implementing Success Criteria: Issue comment helper queue を止め、未接続を明示 blocked にする。
+- Explicit Non-goals: pagination 修正、VPS live mutation、deploy、credential/permission mutation、Issue close。
+- Expected touched files/routes/workflows: Worker Dashboard chat route、VPS helper queue route、passkey operator page、queue docs/tests、generated worker。
+- Affected Issues: #741, #637, #413, #450
+- Affected PRs: follow-up to PR #823, PR #824, PR #825
+- Affected workflows: deploy 後 bridge helper continuation は local queue 未接続として blocked になる。
+- Affected runtime/operator surfaces: Dashboard Butler、passkey operator、VPS privileged maintenance helper queue route。
+- What may break if we patch narrowly: bridge restart の実行能力は一時的に blocked になる。ただし Issue コメント蓄積と silent drop を止めるため意図した挙動。
+- Unknowns to investigate before coding: VPS local queue/state/log transport の実装詳細。
+- Validation needed: `node --test test/worker.test.js`; `node --test test/vps-runner-script.test.js`; `npm run build:worker`; `npm test`
+- Stop condition: Issue comment transport の延命が必要になる場合。
+
+## Execution Queue Delta
+
+- Queue position before: Issue #816 was `Now` for Dashboard Butler follow-up queue media/UI.
+- Preemption decision: ROOT。Issue #741 の helper queue defect は Issue #637 privileged maintenance、Issue #413 runtime truth、Issue #450 app-server path を横断して壊すため preempt する。
+- Queue delta: Issue #741 moves to `Now` for this safety slice. Issue #816 moves to `Next` and remains active.
+- Why this PR is next: pagination 修正で旧 Issue comment transport を延命すると、コメント蓄積と silent pickup gap が残るため。
+- Active Issues not downscoped: Active Issues are not downscoped. #816 / #814 / #811 / #637 remain active and incomplete.
+
+## File / Line Hypotheses
+
+- file: `src/worker/runtime.js`
+  - hypothesis: `createVpsPrivilegedMaintenanceHelperExecutionQueue` が valid envelope を GitHub Issue comment create に変換しているため、queue が溜まり続ける。
+  - risk if changed narrowly: blocked flow が Dashboard Butler から消えると operator が `unknown` に戻る。
+  - validation: worker tests。
+  - related Issue: #741
+- file: `src/core/passkey-operator-page.js`
+  - hypothesis: queued 以外の continuation response を `unknown` 扱いしている。
+  - risk if changed narrowly: owner が blocker reason を読めない。
+  - validation: worker operator page tests。
+  - related Issue: #741
+
+## Hypothesis Retrospective
+
+- expected: Issue comment queue write を止めても Dashboard Butler / operator には blocked reason が残る。
+- actual: worker tests confirmed helper continuation, low-risk read/status, and DashboardChatRoom VPS maintenance flows return blocked without GitHub comment creation.
+- mismatch: low-risk blocked flow initially fell through to app-server bridge; `shouldDashboardVpsMaintenanceFlowStayInWorker` was updated to keep local queue unavailable blockers in Worker.
+- lesson: Issue comment transport blockers must remain visible in the owner surface; otherwise the system silently falls back to the wrong path.
+- should become RAG candidate: VPS helper execution queue must not use GitHub Issue comments; use bounded VPS-local queue/state/log and report only result/postmortem to Dashboard/GitHub.
+
+## Verification Evidence
+
+- Unit: `node --test test/worker.test.js` passed: 292 tests pass.
+- Unit: `node --test test/vps-runner-script.test.js` passed: 79 tests pass.
+- Build: `npm run build:worker` passed.
+- Integration: `npm test` passed: 1243 tests, 1242 pass, 1 skipped; self-parity passed; generated-worker check passed.
+- E2E: 未実施。merge/deploy 後に passkey operator continuation が Issue コメントを増やさず blocked reason を表示する live check が必要。
+- Evidence path/link: `docs/development-strategy/issue-741-stop-issue-comment-helper-queue.md`
+
+## Butler Completion Contract
+
+- Primary owner surface: Dashboard Butler。
+- Fallback surface: Custom GPT は明示された fallback surface として扱います。
+- Owner goal: Issue コメントに VPS helper execution request を溜め続けない。
+- Butler entrypoint: `/v2/dashboard/chat/messages`
+- Dashboard Butler natural-language path: Dashboard Butler chat entrypoint `/v2/dashboard/chat/messages` で natural-language maintenance intent / passkey continuation は blocked reason を返す。
+- Action Schema exposure: 変更なし。
+- Runtime path: Worker route は Issue comment queue write を停止し、local queue 未接続を blocked として返す。
+- Runner/runtime truth: `queueCommentPosted=false`, `rootExecutionStarted=false`, `helperExecutionStarted=false`。
+- Authority boundary: deploy / credential / permission / VPS systemd / root execution は未実施。
+- E2E evidence: 未実施。
+- Completion status: incomplete
+
+## Surface Update Checklist
+
+- Cloudflare deploy: merge 後に別途必要。
+- Custom GPT Action Schema update: 不要。
+- Custom GPT Instructions update: 不要。
+- iPhone Butler live E2E: 未実施。
+
+## Related Constitution Rules
+
+- AGENTS.md Butler Completion Gate
+- AGENTS.md Butler-First Operating Principle
+- AGENTS.md Chief Butler Operating Principle
+- AGENTS.md Authority Boundary
+- AGENTS.md Evidence Discipline
+- docs/butler/execution-queue-contract.md
+
+## Out-of-scope but NOT implemented
+
+- VPS local helper queue/state/log writer
+- VPS local queue consumer service
+- bridge restart execution
+- watchdog timer live install/enable
+- existing Issue comment cleanup
+- Issue #741 close
+
+## Extra changes (if any)
+
+None.

--- a/.vtdd/pr-body-issue-741-stop-issue-comment-helper-queue.md
+++ b/.vtdd/pr-body-issue-741-stop-issue-comment-helper-queue.md
@@ -1,0 +1,138 @@
+## This PR satisfies Intent
+
+Issue #741 の follow-up として、VPS privileged maintenance helper execution を GitHub Issue コメント queue に溜め続ける旧経路を止めます。
+
+この PR は pagination 修正ではありません。Issue コメント transport を延命せず、Dashboard Butler / passkey operator continuation は `vps_local_helper_queue_unavailable` として blocked を返し、GitHub Issue comment を作らず、root/helper execution を開始しません。
+
+## Satisfied Success Criteria
+
+- [x] Dashboard Butler / passkey operator continuation が VPS helper execution queue として GitHub Issue コメントを作らない。
+- [x] valid helper execution envelope でも、VPS local queue/state/log transport が未接続なら owner-facing に `blocked` を返す。
+- [x] blocked runtime truth に `queueCommentPosted=false`, `rootExecutionStarted=false`, `helperExecutionStarted=false`, `disabledTransport=github_issue_comment_queue`, `requiredTransport=vps_local_helper_queue` を残す。
+- [x] passkey operator は queued 以外を `unknown` にせず、blocked reason と next action を表示する。
+- [x] low-risk read/status も Issue コメント queue へ流さない。
+
+## Unsatisfied Success Criteria
+
+- VPS local queue/state/log writer / consumer はこの PR では未接続。
+- bridge restart の live 実行、before/after truth、watchdog timer install/enable は未実施。
+- 既存 Issue #741 に溜まった過去 queue コメントの cleanup は未実施。
+- Issue #741 close は未実施。
+
+## Non-goal violations
+
+None.
+
+## 開発前作戦図
+
+- 作戦図 evidence: `docs/development-strategy/issue-741-stop-issue-comment-helper-queue.md`
+- 完了体験: Issue コメントに実行依頼 JSON が溜まり続けず、未接続なら Dashboard Butler / operator に blocked reason が返る。
+- VTDD 全体で進める部分: Issue #741 / #637 / #413 / #450 を横断する Issue comment helper queue defect を止める。
+- 設計: `helper-execution-queues` は Issue comment を書かず、`vps_local_helper_queue_unavailable` blocked を返す。local queue 未接続の blocked は Worker 側 owner-facing reply として残す。
+- 仮説: 原因は pagination ではなく GitHub Issue comment transport 自体である、という仮説で実装前に検証する。
+- 検証計画: worker unit、vps-runner script unit、generated worker、full `npm test`。
+- 改修見積もり: `src/worker/runtime.js`, `src/core/passkey-operator-page.js`, `test/worker.test.js`, `test/active-issue-execution-queue.test.js`, `docs/mvp/active-issue-execution-queue.md`, `worker.js`。
+- 既に通っている経路: proposal / passkey operator URL / helper envelope generation。
+- 未確認の境界: VPS local queue format, retention, consumer service。
+- 穴が出そうな箇所: blocked flow が app-server bridge に流れる、low-risk read が旧 queue に残る、operator が unknown に戻る。
+- PR 前に確認すること: GitHub Issue comment create が呼ばれないこと、runtime truth が blocked を示すこと、root/helper execution が開始しないこと。
+- 実装候補と捨てた案: pagination 修正は旧 transport 延命なので不採用。
+- merge 後に通す E2E: E2E evidence として passkey operator live continuation を実行し、Issue コメントが増えず blocked reason が表示されることを確認する。
+- 次の PR を増やさない理由: これは safety slice。VPS local queue の full implementation は別 PR で authority / retention / E2E を扱う。
+- 停止条件: deploy、credential mutation、permission mutation、root/sudo、VPS systemd install/enable が必要になる場合。
+
+## Dry-run Impact Report
+
+- Target Issue: #741
+- Implementing Success Criteria: Issue comment helper queue を止め、未接続を明示 blocked にする。
+- Explicit Non-goals: pagination 修正、VPS live mutation、deploy、credential/permission mutation、Issue close。
+- Expected touched files/routes/workflows: Worker Dashboard chat route、VPS helper queue route、passkey operator page、queue docs/tests、generated worker。
+- Affected Issues: #741, #637, #413, #450
+- Affected PRs: follow-up to PR #823, PR #824, PR #825
+- Affected workflows: deploy 後 bridge helper continuation は local queue 未接続として blocked になる。
+- Affected runtime/operator surfaces: Dashboard Butler、passkey operator、VPS privileged maintenance helper queue route。
+- What may break if we patch narrowly: bridge restart の実行能力は一時的に blocked になる。ただし Issue コメント蓄積と silent drop を止めるため意図した挙動。
+- Unknowns to investigate before coding: VPS local queue/state/log transport の実装詳細。
+- Validation needed: `node --test test/worker.test.js`; `node --test test/vps-runner-script.test.js`; `npm run build:worker`; `npm test`
+- Stop condition: Issue comment transport の延命が必要になる場合。
+
+## Execution Queue Delta
+
+- Queue position before: Issue #816 was `Now` for Dashboard Butler follow-up queue media/UI.
+- Preemption decision: ROOT。Issue #741 の helper queue defect は Issue #637 privileged maintenance、Issue #413 runtime truth、Issue #450 app-server path を横断して壊すため preempt する。
+- Queue delta: Issue #741 moves to `Now` for this safety slice. Issue #816 moves to `Next` and remains active.
+- Why this PR is next: pagination 修正で旧 Issue comment transport を延命すると、コメント蓄積と silent pickup gap が残るため。
+- Active Issues not downscoped: Active Issues are not downscoped. #816 / #814 / #811 / #637 remain active and incomplete.
+
+## File / Line Hypotheses
+
+- file: `src/worker/runtime.js`
+  - hypothesis: `createVpsPrivilegedMaintenanceHelperExecutionQueue` が valid envelope を GitHub Issue comment create に変換しているため、queue が溜まり続ける。
+  - risk if changed narrowly: blocked flow が Dashboard Butler から消えると operator が `unknown` に戻る。
+  - validation: worker tests。
+  - related Issue: #741
+- file: `src/core/passkey-operator-page.js`
+  - hypothesis: queued 以外の continuation response を `unknown` 扱いしている。
+  - risk if changed narrowly: owner が blocker reason を読めない。
+  - validation: worker operator page tests。
+  - related Issue: #741
+
+## Hypothesis Retrospective
+
+- expected: Issue comment queue write を止めても Dashboard Butler / operator には blocked reason が残る。
+- actual: worker tests confirmed helper continuation, low-risk read/status, and DashboardChatRoom VPS maintenance flows return blocked without GitHub comment creation.
+- mismatch: low-risk blocked flow initially fell through to app-server bridge; `shouldDashboardVpsMaintenanceFlowStayInWorker` was updated to keep local queue unavailable blockers in Worker.
+- lesson: Issue comment transport blockers must remain visible in the owner surface; otherwise the system silently falls back to the wrong path.
+- should become RAG candidate: VPS helper execution queue must not use GitHub Issue comments; use bounded VPS-local queue/state/log and report only result/postmortem to Dashboard/GitHub.
+
+## Verification Evidence
+
+- Unit: `node --test test/worker.test.js` passed: 292 tests pass.
+- Unit: `node --test test/vps-runner-script.test.js` passed: 79 tests pass.
+- Build: `npm run build:worker` passed.
+- Integration: `npm test` passed: 1243 tests, 1242 pass, 1 skipped; self-parity passed; generated-worker check passed.
+- E2E: 未実施。merge/deploy 後に passkey operator continuation が Issue コメントを増やさず blocked reason を表示する live check が必要。
+- Evidence path/link: `docs/development-strategy/issue-741-stop-issue-comment-helper-queue.md`
+
+## Butler Completion Contract
+
+- Primary owner surface: Dashboard Butler。
+- Fallback surface: Custom GPT は明示された fallback surface として扱います。
+- Owner goal: Issue コメントに VPS helper execution request を溜め続けない。
+- Butler entrypoint: `/v2/dashboard/chat/messages`
+- Dashboard Butler natural-language path: Dashboard Butler chat entrypoint `/v2/dashboard/chat/messages` で natural-language maintenance intent / passkey continuation は blocked reason を返す。
+- Action Schema exposure: 変更なし。
+- Runtime path: Worker route は Issue comment queue write を停止し、local queue 未接続を blocked として返す。
+- Runner/runtime truth: `queueCommentPosted=false`, `rootExecutionStarted=false`, `helperExecutionStarted=false`。
+- Authority boundary: deploy / credential / permission / VPS systemd / root execution は未実施。
+- E2E evidence: 未実施。
+- Completion status: incomplete
+
+## Surface Update Checklist
+
+- Cloudflare deploy: merge 後に別途必要。
+- Custom GPT Action Schema update: 不要。
+- Custom GPT Instructions update: 不要。
+- iPhone Butler live E2E: 未実施。
+
+## Related Constitution Rules
+
+- AGENTS.md Butler Completion Gate
+- AGENTS.md Butler-First Operating Principle
+- AGENTS.md Chief Butler Operating Principle
+- AGENTS.md Authority Boundary
+- AGENTS.md Evidence Discipline
+- docs/butler/execution-queue-contract.md
+
+## Out-of-scope but NOT implemented
+
+- VPS local helper queue/state/log writer
+- VPS local queue consumer service
+- bridge restart execution
+- watchdog timer live install/enable
+- existing Issue comment cleanup
+- Issue #741 close
+
+## Extra changes (if any)
+
+None.

--- a/docs/development-strategy/issue-741-stop-issue-comment-helper-queue.md
+++ b/docs/development-strategy/issue-741-stop-issue-comment-helper-queue.md
@@ -1,0 +1,133 @@
+# Issue #741 stop Issue comment helper queue
+
+## 完了体験
+
+Owner が Dashboard Butler / passkey operator から bridge restart / VPS helper
+handoff を進めても、GitHub Issue コメントに実行依頼 JSON が溜まり続けない。
+VPS local queue / state / log の接続がまだ無い場合は、実行を始めず
+`blocked` として Dashboard Butler と operator に理由を返す。
+
+この PR は bridge restart を完了させる PR ではない。Issue コメント transport
+を延命せず止める safety PR である。
+
+## VTDD 全体で進める部分
+
+Issue #741 の deploy 後 bridge sync/restart と Issue #637 の VPS privileged
+maintenance handoff が、GitHub Issue コメントを実行 queue として使い続ける
+root defect を止める。Issue #413 の runtime truth と Issue #450 の app-server
+path に対して、silent accumulation / silent drop を持ち込まない。
+
+## 設計
+
+- Worker の `helper-execution-queues` は Issue コメントを書かない。
+- 現時点では VPS local helper queue writer が Worker から到達可能ではないため、
+  `vps_local_helper_queue_unavailable` として blocked を返す。
+- blocked runtime truth は `queueCommentPosted=false`、`rootExecutionStarted=false`、
+  `helperExecutionStarted=false`、`requiredTransport=vps_local_helper_queue` を含める。
+- Dashboard Butler の自然文 continuation は `queued_for_vps_helper_execution` を
+  成功扱いしない。blocked reply を owner-facing に返す。
+- passkey operator は queued 以外を `unknown` にしない。blocked status / error /
+  next action を表示する。
+- VPS runner 側の既存 `vtdd:vps-privileged-maintenance-execution` pickup は、
+  新規実行 path として使わない。既存コメントの後始末や historical parser は
+  この PR では削除しない。
+
+## 仮説
+
+今回の破綻は pagination ではなく、GitHub Issue コメントを VPS helper execution
+queue として使っていたことが本体である。PR #824 は self-healing watchdog では
+Issue コメント方式を避けたが、PR #823 / #825 の approval continuation 経路には
+旧 Issue comment queue が残った。そこを pagination で直すと、溜まり続ける設計を
+延命する。
+
+## 検証計画
+
+- Unit: passkey approval continuation は `blocked` を返し、GitHub Issue comment
+  create を呼ばない。
+- Unit: `/v2/vps/privileged-maintenance/helper-execution-queues` は valid envelope
+  でも `503` blocked を返し、`queueCommentPosted=false` を返す。
+- Unit: low-risk read も Issue コメント queue へ流さず blocked になる。
+- Unit: passkey operator page は queued 以外を `unknown` ではなく blocked reason
+  として表示する。
+- Generated worker: `npm run build:worker`
+- Integration: `node --test test/worker.test.js`
+- Regression: `node --test test/vps-runner-script.test.js` は既存 runner parser
+  compatibility の確認として走らせる。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`
+  - `createVpsPrivilegedMaintenanceHelperExecutionQueue`: Issue comment write
+    plane を止め、local queue unavailable blocked response を返す。
+  - Dashboard natural-language flow: blocked response visibility を維持し、
+    `helperQueueReached=false` を返す。
+  - owner-facing reply: `queueCommentUrl` 前提を外し、local queue 未接続を明示する。
+- `src/core/passkey-operator-page.js`
+  - queued 以外を `unknown` にしない。`blocked` / runtime truth / next action を表示する。
+- `test/worker.test.js`
+  - 既存 queue success assertions を blocked / no GitHub comment に更新する。
+- `worker.js`
+  - Worker bundle regeneration。
+
+## 既に通っている経路
+
+- Proposal 作成と passkey operator URL 生成は PR #825 後に live で到達済み。
+- Worker の helper execution envelope 作成は validation 済み。
+- PR #824 の watchdog script/template は local state/log 方針を採用済みだが、
+  live install/enable は未実施。
+
+## 未確認の境界
+
+- Worker から VPS local queue/state/log へ直接渡す runtime route は未接続。
+- VPS local queue のファイル形式、retention、single-flight、consumer service は
+  この PR では未実装。
+- 既存 Issue コメント queue の historical cleanup は未実施。
+
+## 穴が出そうな箇所
+
+- queued 成功を期待する tests / operator UI が blocked を失敗表示として
+  `unknown` に戻す。
+- low-risk read まで Issue コメント transport に残る。
+- runner 側 parser を削除しすぎて historical progress / event parsing を壊す。
+- deploy 後 bridge restart の実行能力が一時的に blocked になることを PR body で
+  明示しないと、completion overclaim になる。
+
+## PR 前に確認すること
+
+- GitHub Issue comment create が valid helper queue path で呼ばれないこと。
+- `queueCommentPosted=false` が runtime truth に残ること。
+- root/helper execution は開始しないこと。
+- passkey operator が blocked reason を表示し、`unknown` にしないこと。
+- PR body に `Completion status: incomplete` と local queue 未接続を明記すること。
+
+## 実装候補と捨てた案
+
+- 採用: Issue comment queue を即時 blocked にし、VPS local queue 未接続を明示する。
+- 捨てた案: `/issues/{number}/comments` pagination を修正して拾えるようにする。
+  これは溜まり続ける設計を延命するため不採用。
+- 捨てた案: mac Codex / SSH から直接 restart して完了扱いする。Butler-first
+  completion を満たさないため不採用。
+- 捨てた案: Worker から root helper を直接実行する。authority boundary を越えるため
+  不採用。
+
+## merge 後に通す E2E
+
+- Dashboard Butler で bridge restart intent を出し、approval URL が出ること。
+- passkey 承認後、Issue コメントが増えず、Dashboard / operator に
+  `vps_local_helper_queue_unavailable` blocked が返ること。
+- VPS runner が新規 Issue comment queue を拾わないこと。
+- 次 PR で VPS local queue writer / consumer / bounded log / retention を接続し、
+  bridge restart before/after truth を事後報告する。
+
+## 次の PR を増やさない理由
+
+この PR は危険な旧 transport を止める emergency safety slice であり、VPS local queue
+の full implementation まで同時に入れると authority boundary、VPS service design、
+retention、E2E が膨らむ。まず Issue コメント蓄積を止める。
+
+## 停止条件
+
+- deploy、credential mutation、permission mutation、root/sudo 実行、VPS systemd
+  install/enable が必要になった場合。
+- Issue コメント transport を pagination で延命しないと tests が通らない場合。
+- local queue 未接続を隠して queued success として扱う必要が出た場合。

--- a/docs/mvp/active-issue-execution-queue.md
+++ b/docs/mvp/active-issue-execution-queue.md
@@ -183,20 +183,30 @@ Last rebuilt from GitHub runtime truth: 2026-06-05
   appear above the composer, not keep accumulating below it, and must expose
   queue / guide / edit / cancel choices. This keeps Issue #816 as `Now` until
   PR #817 is updated.
+- 2026-06-07 owner input classified Issue #741 as `ROOT`: deploy 後 bridge
+  restart / VPS helper handoff が GitHub Issue comment queue に戻っており、
+  Issue #741 に実行依頼コメントが溜まり続け、VPS runner pickup も silent
+  drop していた。これは Issue #637 privileged maintenance、Issue #413 runtime
+  truth、Issue #450 app-server path を横断して壊すため、pagination 修正で
+  延命せず、Issue comment helper queue を止める safety slice が `Now` に
+  preempt する。Issue #816 / #814 / #811 は active のまま、#741 safety slice
+  の後に再開する。
 
 ## Now
 
-- Issue #816: Dashboard Butler 差し込み queue が添付を落とさないようにする。
-  Issue #814 の voice mode 実装前に、実行中差し込み queue が
-  `mediaReferences: []` 固定送信で添付を失う欠陥と、入力欄の下へ
-  差し込みを積み続ける UX 欠陥を直す。差し込み queue item は upload 済み
-  media reference を保持し、composer 上に queue / guide / edit / cancel を
-  owner-facing に出し、送信時に Dashboard thread と codex app-server bridge
-  turn input へ渡す。Issue #811 は parent root として active のまま残り、
-  この PR だけで #811 / #814 / #818 completion とは扱わない。
+- Issue #741: GitHub Issue comment を VPS privileged maintenance helper
+  execution queue として使う旧経路を止める。pagination 修正ではなく、
+  Dashboard Butler / passkey operator continuation は Issue comment を作らず
+  `vps_local_helper_queue_unavailable` blocked を返し、root/helper execution
+  を開始しない。これは safety slice であり、VPS local queue/state/log consumer
+  の接続、bridge restart 完了、watchdog live install/enable、Issue #741 close は
+  次 slice に残る。
 
 ## Next
 
+- Issue #816: Dashboard Butler 差し込み queue が添付を落とさないようにする。
+  Issue #741 の Issue comment helper queue safety slice 後に、実行中差し込み
+  queue の添付保持と composer 上 queue UI を再開する。
 - Issue #814: Dashboard Butler voice mode で VPS 返信を読み上げる。
   Issue #816 が merged / verified された後に、発話 transcript、VPS
   handoff、返信読み上げ、Wake Lock、終了時 cleanup の owner-facing workflow

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -858,7 +858,7 @@ export function renderPasskeyOperatorPage(input = {}) {
         }
         const repositoryInput = readRequiredRepositoryInput();
         const issueNumber = Number(document.getElementById("issue-input").value || 0) || null;
-        setApproveOutput("パスキー承認済み。Dashboard Butler へ戻して VPS helper queue へ進めています...", {
+        setApproveOutput("パスキー承認済み。Dashboard Butler へ戻して VPS helper queue 接続状態を確認しています...", {
           show: shouldShowApproveOutput("status")
         });
         const continueResponse = await fetch("${apiBase}/dashboard/chat/messages", {
@@ -880,9 +880,13 @@ export function renderPasskeyOperatorPage(input = {}) {
         }
         const runtimeTruth = continueBody?.execution?.runtimeTruth || {};
         if (continueBody?.execution?.status !== "queued_for_vps_helper_execution") {
+          const executionStatus = continueBody?.execution?.status || "blocked";
+          const errorText = continueBody?.error || continueBody?.execution?.runtimeTruth?.status || executionStatus;
+          const nextAction = continueBody?.execution?.runtimeTruth?.nextAction || continueBody?.runtimeTruth?.nextAction || "";
           throw new Error(
-            "VPS helper queue handoff did not queue. "
-            + (runtimeTruth.status || continueBody?.execution?.status || "unknown")
+            "VPS helper queue handoff blocked. "
+            + errorText
+            + (nextAction ? ". next action: " + nextAction : "")
           );
         }
         setApproveOutput("VPS helper queue へ渡しました。Dashboard Butler と通知で進捗を確認してください。", {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -6683,74 +6683,44 @@ async function createVpsPrivilegedMaintenanceHelperExecutionQueue({ payload, env
       payload?.threadId ||
       payload?.thread_id
   );
-  const queueCommentBody = buildVpsPrivilegedMaintenanceQueueComment({
-    executionId,
-    repository,
-    issueNumber,
-    dashboardThreadId,
-    approvalActor: payload?.approvalActor,
-    executionEnvelope: envelope
-  });
-  const writeResult = await executeGitHubWritePlane({
-    operation: "issue_comment_create",
-    repository,
-    issueNumber,
-    body: queueCommentBody,
-    approvalPhrase: "GO",
-    targetConfirmed: true,
-    approvalScopeMatched: true,
-    env
-  });
-  if (!writeResult.ok) {
-    const body = {
-      ok: false,
-      error: writeResult.error || "vps_privileged_maintenance_queue_post_failed",
-      reason: writeResult.reason,
-      issues: writeResult.issues ?? [],
-      runtimeTruth: {
-        kind: "vps_privileged_maintenance_helper_execution_queue",
-        status: "failed",
-        rootExecutionStarted: false,
-        helperExecutionStarted: false,
-        queueCommentPosted: false,
-        redacted: true
-      }
-    };
-    return {
-      ok: false,
-      status: writeResult.status ?? 503,
-      error: body.error,
-      reason: body.reason,
-      issues: body.issues,
-      body
-    };
-  }
 
   const body = {
-    ok: true,
+    ok: false,
+    error: "vps_local_helper_queue_unavailable",
+    reason:
+      "GitHub Issue comments are no longer accepted as the VPS privileged maintenance helper execution queue.",
+    issues: [
+      "Issue comment queue transport is disabled to avoid unbounded comment accumulation and silent pickup gaps.",
+      "A bounded VPS-local helper queue/state/log transport must be connected before this execution can be queued."
+    ],
     execution: {
       executionId,
-      transport: "vps_privileged_maintenance_helper",
+      transport: "vps_local_helper_queue",
       repository,
       issueNumber,
       dashboardThreadId: dashboardThreadId || null,
-      queueCommentId: writeResult.write?.commentId || null,
-      queueCommentUrl: writeResult.write?.url || null,
-      status: "queued"
+      queueCommentId: null,
+      queueCommentUrl: null,
+      status: "blocked"
     },
     runtimeTruth: {
       kind: "vps_privileged_maintenance_helper_execution_queue",
-      status: "queued_for_vps_helper_execution",
+      status: "vps_local_helper_queue_unavailable",
       rootExecutionStarted: false,
       helperExecutionStarted: false,
-      queueCommentPosted: true,
+      queueCommentPosted: false,
       dashboardThreadIdIncluded: Boolean(dashboardThreadId),
-      nextAction: "VPS runner must pick up the vtdd:vps-privileged-maintenance-execution queue comment and invoke the root-owned helper"
+      requiredTransport: "vps_local_helper_queue",
+      disabledTransport: "github_issue_comment_queue",
+      nextAction: "Connect a bounded VPS-local helper queue/state/log transport before retrying this maintenance execution."
     }
   };
   return {
-    ok: true,
-    status: 200,
+    ok: false,
+    status: 503,
+    error: body.error,
+    reason: body.reason,
+    issues: body.issues,
     body
   };
 }
@@ -12800,7 +12770,12 @@ async function buildDashboardChatTurn(payload, options = {}) {
 
 function shouldDashboardVpsMaintenanceFlowStayInWorker(flow = null, options = {}) {
   const status = normalizeText(flow?.execution?.status || flow?.messageStatus);
+  const runtimeTruth = flow?.execution?.runtimeTruth || {};
   return ["approval_required", "queued_for_vps_helper_execution", "sent"].includes(status) ||
+    (status === "blocked" &&
+      (normalizeText(runtimeTruth.requiredTransport) === "vps_local_helper_queue" ||
+        normalizeText(runtimeTruth.disabledTransport) === "github_issue_comment_queue" ||
+        normalizeText(runtimeTruth.status) === "vps_local_helper_queue_unavailable")) ||
     (options.approvalContinuation === true && status === "blocked");
 }
 
@@ -13042,7 +13017,8 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
         relatedIssue,
         error: queue.error,
         reason: queue.reason,
-        issues: queue.issues
+        issues: queue.issues,
+        nextAction: queue.body?.runtimeTruth?.nextAction
       });
 
   return {
@@ -13178,7 +13154,8 @@ async function queueDashboardVpsMaintenanceLowRiskRead({
         relatedIssue,
         error: queue.error,
         reason: queue.reason,
-        issues: queue.issues
+        issues: queue.issues,
+        nextAction: queue.body?.runtimeTruth?.nextAction
       });
 
   return {

--- a/test/active-issue-execution-queue.test.js
+++ b/test/active-issue-execution-queue.test.js
@@ -85,15 +85,17 @@ test("active issue execution queue names current open PR hygiene", () => {
 });
 
 test("active issue execution queue names the next automatic implementation lane", () => {
-  assert.equal(sectionBody("Now").includes("Issue #816: Dashboard Butler 差し込み queue が添付を落とさないようにする"), true);
-  assert.equal(sectionBody("Now").includes("queue / guide / edit / cancel"), true);
-  assert.equal(sectionBody("Now").includes("Issue #811 は parent root"), true);
+  assert.equal(sectionBody("Now").includes("Issue #741: GitHub Issue comment を VPS privileged maintenance helper"), true);
+  assert.equal(sectionBody("Now").includes("vps_local_helper_queue_unavailable"), true);
+  assert.equal(sectionBody("Now").includes("root/helper execution"), true);
   assert.equal(doc.includes("2026-06-06 owner input classified Issue #811 as `ROOT`"), true);
   assert.equal(doc.includes("2026-06-06 owner input classified Issue #814 as `ROOT` support for Issue"), true);
   assert.equal(doc.includes("2026-06-06 owner input classified Issue #816 as `NEXT`"), true);
   assert.equal(doc.includes("2026-06-07 owner input classified Issue #818 as `NEXT`"), true);
+  assert.equal(doc.includes("2026-06-07 owner input classified Issue #741 as `ROOT`"), true);
   assert.equal(doc.includes("PR #819 merged Issue #818 voice readback / interrupt gate"), true);
   assert.equal(doc.includes("PR #724 merged and deploy-production succeeded for Issue #723"), true);
+  assert.equal(sectionBody("Next").includes("Issue #816: Dashboard Butler 差し込み queue が添付を落とさないようにする"), true);
   assert.equal(sectionBody("Next").includes("Issue #814: Dashboard Butler voice mode で VPS 返信を読み上げる"), true);
   assert.equal(sectionBody("Next").includes("Issue #637: iPhone/PWA-complete VPS privileged maintenance"), true);
   assert.equal(sectionBody("Evidence Gaps").includes("Issue #606: PR #627 merged and production deployed"), true);

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3325,23 +3325,21 @@ test("worker connects VPS privileged maintenance intent from Dashboard Butler ch
   assert.equal(approvedResponse.status, 202);
   const approvedBody = await approvedResponse.json();
   assert.equal(approvedBody.ok, true);
-  assert.equal(approvedBody.execution.status, "queued_for_vps_helper_execution");
-  assert.equal(approvedBody.execution.queue.dashboardThreadId, "dashboard-main-unresolved");
-  assert.equal(approvedBody.execution.runtimeTruth.helperQueueReached, true);
+  assert.equal(approvedBody.execution.status, "blocked");
+  assert.equal(approvedBody.execution.queue.status, "blocked");
+  assert.equal(approvedBody.execution.queue.transport, "vps_local_helper_queue");
+  assert.equal(approvedBody.execution.runtimeTruth.helperQueueReached, false);
   assert.equal(approvedBody.execution.runtimeTruth.dashboardThreadIdIncluded, true);
+  assert.equal(approvedBody.execution.runtimeTruth.queueCommentPosted, false);
+  assert.equal(approvedBody.execution.runtimeTruth.disabledTransport, "github_issue_comment_queue");
   assert.equal(approvedBody.execution.runtimeTruth.rootExecutionStarted, false);
   assert.equal(approvedBody.execution.runtimeTruth.helperExecutionStarted, false);
   assert.equal(approvedBody.messages[1].role, "butler");
-  assert.equal(approvedBody.messages[1].status, "sent");
-  assert.match(approvedBody.messages[1].text, /VPS runner へ復旧依頼を渡しました/);
-  assert.match(approvedBody.messages[1].text, /bounded handoff/);
+  assert.equal(approvedBody.messages[1].status, "blocked");
+  assert.match(approvedBody.messages[1].text, /vps_local_helper_queue_unavailable/);
+  assert.match(approvedBody.messages[1].text, /Issue comment queue transport is disabled/);
   assert.match(approvedBody.messages[1].text, /rootExecutionStarted=false/);
-  assert.equal(githubCalls.length, 1);
-  const queueCommentBody = JSON.parse(githubCalls[0].init.body).body;
-  assert.equal(queueCommentBody.includes("vtdd:vps-privileged-maintenance-execution:issue637-dashboard-natural-chat"), true);
-  assert.equal(queueCommentBody.includes('"transport": "vps_privileged_maintenance_helper"'), true);
-  assert.equal(queueCommentBody.includes('"dashboardThreadId": "dashboard-main-unresolved"'), true);
-  assert.equal(queueCommentBody.includes('"handoff"'), true);
+  assert.equal(githubCalls.length, 0);
 });
 
 test("worker allows VPS passkey operator continuation without Cloudflare Access dashboard session", async () => {
@@ -3436,13 +3434,13 @@ test("worker allows VPS passkey operator continuation without Cloudflare Access 
   assert.equal(response.status, 202);
   const body = await response.json();
   assert.equal(body.ok, true);
-  assert.equal(body.execution.status, "queued_for_vps_helper_execution");
-  assert.equal(body.execution.runtimeTruth.helperQueueReached, true);
+  assert.equal(body.execution.status, "blocked");
+  assert.equal(body.execution.runtimeTruth.helperQueueReached, false);
+  assert.equal(body.execution.runtimeTruth.queueCommentPosted, false);
+  assert.equal(body.execution.runtimeTruth.disabledTransport, "github_issue_comment_queue");
   assert.equal(body.execution.runtimeTruth.rootExecutionStarted, false);
   assert.equal(body.execution.runtimeTruth.helperExecutionStarted, false);
-  assert.equal(githubCalls.length, 1);
-  const queueCommentBody = JSON.parse(githubCalls[0].init.body).body;
-  assert.equal(queueCommentBody.includes("dashboard_bridge_unresolved_deploy_sync_restart"), true);
+  assert.equal(githubCalls.length, 0);
 });
 
 test("worker treats approvalGrantId and vpsProposalId as VPS continuation intent", async () => {
@@ -3537,11 +3535,12 @@ test("worker treats approvalGrantId and vpsProposalId as VPS continuation intent
   assert.equal(response.status, 202);
   const body = await response.json();
   assert.equal(body.ok, true);
-  assert.equal(body.execution.status, "queued_for_vps_helper_execution");
-  assert.equal(body.execution.runtimeTruth.helperQueueReached, true);
+  assert.equal(body.execution.status, "blocked");
+  assert.equal(body.execution.runtimeTruth.helperQueueReached, false);
+  assert.equal(body.execution.runtimeTruth.queueCommentPosted, false);
   assert.equal(body.messages.length, 2);
-  assert.equal(body.messages[1].status, "sent");
-  assert.equal(githubCalls.length, 1);
+  assert.equal(body.messages[1].status, "blocked");
+  assert.equal(githubCalls.length, 0);
 });
 
 test("worker returns blocked VPS continuation execution instead of dropping it", async () => {
@@ -3621,8 +3620,8 @@ test("worker returns blocked VPS continuation execution instead of dropping it",
   assert.equal(body.execution.vpsProposalId, proposalBody.vpsProposalId);
   assert.equal(body.messages.length, 2);
   assert.equal(body.messages[1].status, "blocked");
-  assert.match(body.messages[1].text, /github_write_unavailable/);
-  assert.match(body.messages[1].text, /GitHub App installation token is unavailable/);
+  assert.match(body.messages[1].text, /vps_local_helper_queue_unavailable/);
+  assert.match(body.messages[1].text, /Issue comment queue transport is disabled/);
 });
 
 test("worker rejects VPS continuation context that does not match the stored proposal", async () => {
@@ -3822,22 +3821,20 @@ test("worker maps Dashboard Butler VPS runner status text to the low-risk preset
   assert.equal(response.status, 202);
   const body = await response.json();
   assert.equal(body.ok, true);
-  assert.equal(body.execution.status, "queued_for_vps_helper_execution");
+  assert.equal(body.execution.status, "blocked");
   assert.equal(body.execution.approvalScope.vpsCapabilityId, "systemd.user.runner.status");
   assert.equal(body.execution.approvalScope.vpsOperation, "review");
   assert.equal(body.execution.runtimeTruth.approvalRequired, false);
   assert.equal(body.execution.runtimeTruth.approvalBypassReason, "low_risk_read");
-  assert.equal(body.execution.runtimeTruth.helperQueueReached, true);
+  assert.equal(body.execution.runtimeTruth.helperQueueReached, false);
+  assert.equal(body.execution.runtimeTruth.queueCommentPosted, false);
+  assert.equal(body.execution.runtimeTruth.disabledTransport, "github_issue_comment_queue");
   assert.equal(body.execution.runtimeTruth.rootExecutionStarted, false);
-  assert.equal(body.messages[1].status, "sent");
-  assert.match(body.messages[1].text, /VPS runner へ復旧依頼を渡しました/);
-  assert.match(body.messages[1].text, /low-risk read/);
+  assert.equal(body.messages[1].status, "blocked");
+  assert.match(body.messages[1].text, /vps_local_helper_queue_unavailable/);
+  assert.match(body.messages[1].text, /Issue comment queue transport is disabled/);
   assert.doesNotMatch(body.messages[1].text, /approval URL/);
-  assert.equal(githubCalls.length, 1);
-  const queueCommentBody = JSON.parse(githubCalls[0].init.body).body;
-  assert.equal(queueCommentBody.includes("vtdd:vps-privileged-maintenance-execution:"), true);
-  assert.equal(queueCommentBody.includes('"transport": "vps_privileged_maintenance_helper"'), true);
-  assert.equal(queueCommentBody.includes('"approvalBypassReason": "low_risk_read"'), true);
+  assert.equal(githubCalls.length, 0);
 
   const records = await provider.retrieve({ ids: [body.execution.vpsProposalId] });
   const proposalRecord = records[0];
@@ -3886,20 +3883,18 @@ test("worker detects app-server bridge recovery intent without internal VPS help
   assert.equal(response.status, 202);
   const body = await response.json();
   assert.equal(body.ok, true);
-  assert.equal(body.execution.status, "queued_for_vps_helper_execution");
+  assert.equal(body.execution.status, "blocked");
   assert.equal(body.execution.approvalScope.vpsCapabilityId, "systemd.user.app.server.bridge.status");
   assert.equal(body.execution.approvalScope.vpsOperation, "review");
   assert.equal(body.execution.runtimeTruth.approvalRequired, false);
   assert.equal(body.execution.runtimeTruth.approvalBypassReason, "low_risk_read");
-  assert.equal(body.execution.runtimeTruth.helperQueueReached, true);
+  assert.equal(body.execution.runtimeTruth.helperQueueReached, false);
+  assert.equal(body.execution.runtimeTruth.queueCommentPosted, false);
   assert.equal(body.execution.runtimeTruth.rootExecutionStarted, false);
-  assert.equal(body.messages[1].status, "sent");
-  assert.match(body.messages[1].text, /VPS runner へ復旧依頼を渡しました/);
-  assert.match(body.messages[1].text, /low-risk read/);
+  assert.equal(body.messages[1].status, "blocked");
+  assert.match(body.messages[1].text, /vps_local_helper_queue_unavailable/);
   assert.doesNotMatch(body.messages[1].text, /approval URL/);
-  assert.equal(githubCalls.length, 1);
-  const queueCommentBody = JSON.parse(githubCalls[0].init.body).body;
-  assert.equal(queueCommentBody.includes('"approvalBypassReason": "low_risk_read"'), true);
+  assert.equal(githubCalls.length, 0);
 
   const records = await provider.retrieve({ ids: [body.execution.vpsProposalId] });
   const proposalRecord = records[0];
@@ -3958,13 +3953,7 @@ test("DashboardChatRoom queues repo-less low-risk VPS runner status when reposit
   );
 
   assert.equal(bridgeSocket.sent.length, 0);
-  assert.equal(githubCalls.length, 1);
-  const queueCommentBody = JSON.parse(githubCalls[0].init.body).body;
-  assert.equal(queueCommentBody.includes("vtdd:vps-privileged-maintenance-execution:"), true);
-  assert.equal(queueCommentBody.includes('"repository": "marushu/vtdd-v2-p"'), true);
-  assert.equal(queueCommentBody.includes('"issueNumber": 637'), true);
-  assert.equal(queueCommentBody.includes('"transport": "vps_privileged_maintenance_helper"'), true);
-  assert.equal(queueCommentBody.includes('"approvalBypassReason": "low_risk_read"'), true);
+  assert.equal(githubCalls.length, 0);
 
   const finalBroadcast = dashboardSocket.sent.map((message) => JSON.parse(message)).findLast((message) => message.type === "thread");
   assert.equal(finalBroadcast.type, "thread");
@@ -3973,9 +3962,8 @@ test("DashboardChatRoom queues repo-less low-risk VPS runner status when reposit
   assert.equal(finalBroadcast.messages[0].repository, "marushu/vtdd-v2-p");
   assert.equal(finalBroadcast.messages[0].relatedIssue, 637);
   assert.equal(finalBroadcast.messages[1].role, "butler");
-  assert.equal(finalBroadcast.messages[1].status, "sent");
-  assert.match(finalBroadcast.messages[1].text, /VPS runner へ復旧依頼を渡しました/);
-  assert.match(finalBroadcast.messages[1].text, /low-risk read/);
+  assert.equal(finalBroadcast.messages[1].status, "blocked");
+  assert.match(finalBroadcast.messages[1].text, /vps_local_helper_queue_unavailable/);
   assert.doesNotMatch(finalBroadcast.messages[1].text, /approval URL/);
 });
 
@@ -4862,11 +4850,10 @@ test("DashboardChatRoom routes VPS maintenance owner turns to Worker proposal be
   assert.equal(finalBroadcast.messages.length, 2);
   assert.equal(finalBroadcast.messages[0].role, "owner");
   assert.equal(finalBroadcast.messages[1].role, "butler");
-  assert.equal(finalBroadcast.messages[1].status, "sent");
-  assert.match(finalBroadcast.messages[1].text, /VPS runner へ復旧依頼を渡しました/);
-  assert.match(finalBroadcast.messages[1].text, /low-risk read/);
+  assert.equal(finalBroadcast.messages[1].status, "blocked");
+  assert.match(finalBroadcast.messages[1].text, /vps_local_helper_queue_unavailable/);
   assert.doesNotMatch(finalBroadcast.messages[1].text, /approval URL/);
-  assert.equal(githubCalls.length, 1);
+  assert.equal(githubCalls.length, 0);
 
   const records = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
   const proposalRecord = records.find((record) => record.content?.kind === "vps_privileged_maintenance_approval_proposal");
@@ -4972,11 +4959,10 @@ test("DashboardChatRoom routes VPS maintenance owner turns without an app-server
   assert.equal(finalBroadcast.messages.length, 2);
   assert.equal(finalBroadcast.messages[0].role, "owner");
   assert.equal(finalBroadcast.messages[1].role, "butler");
-  assert.equal(finalBroadcast.messages[1].status, "sent");
-  assert.match(finalBroadcast.messages[1].text, /VPS runner へ復旧依頼を渡しました/);
-  assert.match(finalBroadcast.messages[1].text, /low-risk read/);
+  assert.equal(finalBroadcast.messages[1].status, "blocked");
+  assert.match(finalBroadcast.messages[1].text, /vps_local_helper_queue_unavailable/);
   assert.doesNotMatch(finalBroadcast.messages[1].text, /approval URL/);
-  assert.equal(githubCalls.length, 1);
+  assert.equal(githubCalls.length, 0);
 
   const records = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 10 });
   const proposalRecord = records.find((record) => record.content?.kind === "vps_privileged_maintenance_approval_proposal");
@@ -12053,25 +12039,22 @@ test("worker dry-runs VPS maintenance helper request without root execution", as
     }
   );
 
-  assert.equal(queueResponse.status, 200);
+  assert.equal(queueResponse.status, 503);
   const queueBody = await queueResponse.json();
-  assert.equal(queueBody.ok, true);
+  assert.equal(queueBody.ok, false);
+  assert.equal(queueBody.error, "vps_local_helper_queue_unavailable");
   assert.equal(queueBody.execution.executionId, "vps-maint-test-637");
-  assert.equal(queueBody.execution.transport, "vps_privileged_maintenance_helper");
+  assert.equal(queueBody.execution.transport, "vps_local_helper_queue");
   assert.equal(queueBody.execution.dashboardThreadId, "dashboard-main-marushu-vtdd-v2-p");
-  assert.equal(queueBody.execution.queueCommentId, 63701);
+  assert.equal(queueBody.execution.queueCommentId, null);
   assert.equal(queueBody.runtimeTruth.kind, "vps_privileged_maintenance_helper_execution_queue");
-  assert.equal(queueBody.runtimeTruth.status, "queued_for_vps_helper_execution");
+  assert.equal(queueBody.runtimeTruth.status, "vps_local_helper_queue_unavailable");
   assert.equal(queueBody.runtimeTruth.dashboardThreadIdIncluded, true);
+  assert.equal(queueBody.runtimeTruth.queueCommentPosted, false);
+  assert.equal(queueBody.runtimeTruth.disabledTransport, "github_issue_comment_queue");
   assert.equal(queueBody.runtimeTruth.rootExecutionStarted, false);
   assert.equal(queueBody.runtimeTruth.helperExecutionStarted, false);
-  assert.equal(githubCalls.length, 1);
-  assert.equal(githubCalls[0].url.includes("/repos/marushu/vtdd-v2-p/issues/637/comments"), true);
-  const queueCommentBody = JSON.parse(githubCalls[0].init.body).body;
-  assert.equal(queueCommentBody.includes("vtdd:vps-privileged-maintenance-execution:vps-maint-test-637"), true);
-  assert.equal(queueCommentBody.includes('"transport": "vps_privileged_maintenance_helper"'), true);
-  assert.equal(queueCommentBody.includes('"dashboardThreadId": "dashboard-main-marushu-vtdd-v2-p"'), true);
-  assert.equal(queueCommentBody.includes('"helperExecutionInput"'), true);
+  assert.equal(githubCalls.length, 0);
 });
 
 test("worker retrieves VPS maintenance install inventory without root execution", async () => {

--- a/worker.js
+++ b/worker.js
@@ -28080,7 +28080,7 @@ function renderPasskeyOperatorPage(input = {}) {
         }
         const repositoryInput = readRequiredRepositoryInput();
         const issueNumber = Number(document.getElementById("issue-input").value || 0) || null;
-        setApproveOutput("\u30D1\u30B9\u30AD\u30FC\u627F\u8A8D\u6E08\u307F\u3002Dashboard Butler \u3078\u623B\u3057\u3066 VPS helper queue \u3078\u9032\u3081\u3066\u3044\u307E\u3059...", {
+        setApproveOutput("\u30D1\u30B9\u30AD\u30FC\u627F\u8A8D\u6E08\u307F\u3002Dashboard Butler \u3078\u623B\u3057\u3066 VPS helper queue \u63A5\u7D9A\u72B6\u614B\u3092\u78BA\u8A8D\u3057\u3066\u3044\u307E\u3059...", {
           show: shouldShowApproveOutput("status")
         });
         const continueResponse = await fetch("${apiBase}/dashboard/chat/messages", {
@@ -28102,9 +28102,13 @@ function renderPasskeyOperatorPage(input = {}) {
         }
         const runtimeTruth = continueBody?.execution?.runtimeTruth || {};
         if (continueBody?.execution?.status !== "queued_for_vps_helper_execution") {
+          const executionStatus = continueBody?.execution?.status || "blocked";
+          const errorText = continueBody?.error || continueBody?.execution?.runtimeTruth?.status || executionStatus;
+          const nextAction = continueBody?.execution?.runtimeTruth?.nextAction || continueBody?.runtimeTruth?.nextAction || "";
           throw new Error(
-            "VPS helper queue handoff did not queue. "
-            + (runtimeTruth.status || continueBody?.execution?.status || "unknown")
+            "VPS helper queue handoff blocked. "
+            + errorText
+            + (nextAction ? ". next action: " + nextAction : "")
           );
         }
         setApproveOutput("VPS helper queue \u3078\u6E21\u3057\u307E\u3057\u305F\u3002Dashboard Butler \u3068\u901A\u77E5\u3067\u9032\u6357\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002", {
@@ -63823,111 +63827,44 @@ async function createVpsPrivilegedMaintenanceHelperExecutionQueue({ payload, env
   const dashboardThreadId = normalizeText33(
     payload?.handoff?.dashboardThreadId || payload?.dashboardThreadId || payload?.dashboard_thread_id || payload?.threadId || payload?.thread_id
   );
-  const queueCommentBody = buildVpsPrivilegedMaintenanceQueueComment({
-    executionId,
-    repository,
-    issueNumber,
-    dashboardThreadId,
-    approvalActor: payload?.approvalActor,
-    executionEnvelope: envelope
-  });
-  const writeResult = await executeGitHubWritePlane({
-    operation: "issue_comment_create",
-    repository,
-    issueNumber,
-    body: queueCommentBody,
-    approvalPhrase: "GO",
-    targetConfirmed: true,
-    approvalScopeMatched: true,
-    env
-  });
-  if (!writeResult.ok) {
-    const body2 = {
-      ok: false,
-      error: writeResult.error || "vps_privileged_maintenance_queue_post_failed",
-      reason: writeResult.reason,
-      issues: writeResult.issues ?? [],
-      runtimeTruth: {
-        kind: "vps_privileged_maintenance_helper_execution_queue",
-        status: "failed",
-        rootExecutionStarted: false,
-        helperExecutionStarted: false,
-        queueCommentPosted: false,
-        redacted: true
-      }
-    };
-    return {
-      ok: false,
-      status: writeResult.status ?? 503,
-      error: body2.error,
-      reason: body2.reason,
-      issues: body2.issues,
-      body: body2
-    };
-  }
   const body = {
-    ok: true,
+    ok: false,
+    error: "vps_local_helper_queue_unavailable",
+    reason: "GitHub Issue comments are no longer accepted as the VPS privileged maintenance helper execution queue.",
+    issues: [
+      "Issue comment queue transport is disabled to avoid unbounded comment accumulation and silent pickup gaps.",
+      "A bounded VPS-local helper queue/state/log transport must be connected before this execution can be queued."
+    ],
     execution: {
       executionId,
-      transport: "vps_privileged_maintenance_helper",
+      transport: "vps_local_helper_queue",
       repository,
       issueNumber,
       dashboardThreadId: dashboardThreadId || null,
-      queueCommentId: writeResult.write?.commentId || null,
-      queueCommentUrl: writeResult.write?.url || null,
-      status: "queued"
+      queueCommentId: null,
+      queueCommentUrl: null,
+      status: "blocked"
     },
     runtimeTruth: {
       kind: "vps_privileged_maintenance_helper_execution_queue",
-      status: "queued_for_vps_helper_execution",
+      status: "vps_local_helper_queue_unavailable",
       rootExecutionStarted: false,
       helperExecutionStarted: false,
-      queueCommentPosted: true,
+      queueCommentPosted: false,
       dashboardThreadIdIncluded: Boolean(dashboardThreadId),
-      nextAction: "VPS runner must pick up the vtdd:vps-privileged-maintenance-execution queue comment and invoke the root-owned helper"
+      requiredTransport: "vps_local_helper_queue",
+      disabledTransport: "github_issue_comment_queue",
+      nextAction: "Connect a bounded VPS-local helper queue/state/log transport before retrying this maintenance execution."
     }
   };
   return {
-    ok: true,
-    status: 200,
+    ok: false,
+    status: 503,
+    error: body.error,
+    reason: body.reason,
+    issues: body.issues,
     body
   };
-}
-function buildVpsPrivilegedMaintenanceQueueComment({
-  executionId,
-  repository,
-  issueNumber,
-  dashboardThreadId,
-  approvalActor,
-  executionEnvelope
-} = {}) {
-  const payload = {
-    executionId,
-    transport: "vps_privileged_maintenance_helper",
-    repository,
-    issueNumber,
-    dashboardThreadId: dashboardThreadId || null,
-    handoff: {
-      dashboardThreadId: dashboardThreadId || null
-    },
-    approvalScopeMatched: true,
-    approvalActor: normalizeGitHubLogin(approvalActor) || null,
-    issueTraceability: {
-      canonicalSpec: "github_issue",
-      issueNumber,
-      relatedIssue: issueNumber,
-      issueTraceable: true
-    },
-    executionEnvelope
-  };
-  return [
-    `<!-- vtdd:vps-privileged-maintenance-execution:${executionId} -->`,
-    "VTDD VPS privileged maintenance helper \u5B9F\u884C\u30AD\u30E5\u30FC\u3067\u3059\u3002",
-    "",
-    "\u3053\u306E\u30B3\u30E1\u30F3\u30C8\u306F\u901A\u5E38\u306E Codex branch/PR queue \u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002scoped passkey approval \u6E08\u307F helper execution envelope \u3092 user-owned VPS runner \u304C root-owned helper \u3078\u6E21\u3059\u305F\u3081\u306E bounded handoff \u3067\u3059\u3002",
-    "",
-    fencedJson2(payload)
-  ].join("\n");
 }
 function validateVpsPrivilegedMaintenanceExecutionEnvelopeForQueue(envelope) {
   const issues = [];
@@ -63965,17 +63902,8 @@ function validateVpsPrivilegedMaintenanceExecutionEnvelopeForQueue(envelope) {
   }
   return issues;
 }
-function fencedJson2(value) {
-  return `\`\`\`json
-${JSON.stringify(value, null, 2)}
-\`\`\``;
-}
 function safeIdentifier(value) {
   return String(value || "").replace(/[^A-Za-z0-9_.-]+/g, "_").slice(0, 80) || "execution";
-}
-function normalizeGitHubLogin(value) {
-  const login = normalizeText33(value);
-  return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(login) ? login : "";
 }
 async function handleRetrieveVpsMaintenanceInstallInventoryRequest(url) {
   const inventory = buildVpsPrivilegedMaintenanceInstallInventory({
@@ -69202,7 +69130,8 @@ async function buildDashboardChatTurn(payload, options = {}) {
 }
 function shouldDashboardVpsMaintenanceFlowStayInWorker(flow = null, options = {}) {
   const status = normalizeText33(flow?.execution?.status || flow?.messageStatus);
-  return ["approval_required", "queued_for_vps_helper_execution", "sent"].includes(status) || options.approvalContinuation === true && status === "blocked";
+  const runtimeTruth = flow?.execution?.runtimeTruth || {};
+  return ["approval_required", "queued_for_vps_helper_execution", "sent"].includes(status) || status === "blocked" && (normalizeText33(runtimeTruth.requiredTransport) === "vps_local_helper_queue" || normalizeText33(runtimeTruth.disabledTransport) === "github_issue_comment_queue" || normalizeText33(runtimeTruth.status) === "vps_local_helper_queue_unavailable") || options.approvalContinuation === true && status === "blocked";
 }
 async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
   payload,
@@ -69432,7 +69361,8 @@ async function buildDashboardVpsPrivilegedMaintenanceNaturalLanguageFlow({
     relatedIssue,
     error: queue.error,
     reason: queue.reason,
-    issues: queue.issues
+    issues: queue.issues,
+    nextAction: queue.body?.runtimeTruth?.nextAction
   });
   return {
     messageStatus: queue.ok ? "sent" : "blocked",
@@ -69560,7 +69490,8 @@ async function queueDashboardVpsMaintenanceLowRiskRead({
     relatedIssue,
     error: queue.error,
     reason: queue.reason,
-    issues: queue.issues
+    issues: queue.issues,
+    nextAction: queue.body?.runtimeTruth?.nextAction
   });
   return {
     messageStatus: queue.ok ? "sent" : "blocked",


### PR DESCRIPTION
## This PR satisfies Intent

Issue #741 の follow-up として、VPS privileged maintenance helper execution を GitHub Issue コメント queue に溜め続ける旧経路を止めます。

この PR は pagination 修正ではありません。Issue コメント transport を延命せず、Dashboard Butler / passkey operator continuation は `vps_local_helper_queue_unavailable` として blocked を返し、GitHub Issue comment を作らず、root/helper execution を開始しません。

## Satisfied Success Criteria

- [x] Dashboard Butler / passkey operator continuation が VPS helper execution queue として GitHub Issue コメントを作らない。
- [x] valid helper execution envelope でも、VPS local queue/state/log transport が未接続なら owner-facing に `blocked` を返す。
- [x] blocked runtime truth に `queueCommentPosted=false`, `rootExecutionStarted=false`, `helperExecutionStarted=false`, `disabledTransport=github_issue_comment_queue`, `requiredTransport=vps_local_helper_queue` を残す。
- [x] passkey operator は queued 以外を `unknown` にせず、blocked reason と next action を表示する。
- [x] low-risk read/status も Issue コメント queue へ流さない。

## Unsatisfied Success Criteria

- VPS local queue/state/log writer / consumer はこの PR では未接続。
- bridge restart の live 実行、before/after truth、watchdog timer install/enable は未実施。
- 既存 Issue #741 に溜まった過去 queue コメントの cleanup は未実施。
- Issue #741 close は未実施。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-741-stop-issue-comment-helper-queue.md`
- 完了体験: Issue コメントに実行依頼 JSON が溜まり続けず、未接続なら Dashboard Butler / operator に blocked reason が返る。
- VTDD 全体で進める部分: Issue #741 / #637 / #413 / #450 を横断する Issue comment helper queue defect を止める。
- 設計: `helper-execution-queues` は Issue comment を書かず、`vps_local_helper_queue_unavailable` blocked を返す。local queue 未接続の blocked は Worker 側 owner-facing reply として残す。
- 仮説: 原因は pagination ではなく GitHub Issue comment transport 自体である、という仮説で実装前に検証する。
- 検証計画: worker unit、vps-runner script unit、generated worker、full `npm test`。
- 改修見積もり: `src/worker/runtime.js`, `src/core/passkey-operator-page.js`, `test/worker.test.js`, `test/active-issue-execution-queue.test.js`, `docs/mvp/active-issue-execution-queue.md`, `worker.js`。
- 既に通っている経路: proposal / passkey operator URL / helper envelope generation。
- 未確認の境界: VPS local queue format, retention, consumer service。
- 穴が出そうな箇所: blocked flow が app-server bridge に流れる、low-risk read が旧 queue に残る、operator が unknown に戻る。
- PR 前に確認すること: GitHub Issue comment create が呼ばれないこと、runtime truth が blocked を示すこと、root/helper execution が開始しないこと。
- 実装候補と捨てた案: pagination 修正は旧 transport 延命なので不採用。
- merge 後に通す E2E: E2E evidence として passkey operator live continuation を実行し、Issue コメントが増えず blocked reason が表示されることを確認する。
- 次の PR を増やさない理由: これは safety slice。VPS local queue の full implementation は別 PR で authority / retention / E2E を扱う。
- 停止条件: deploy、credential mutation、permission mutation、root/sudo、VPS systemd install/enable が必要になる場合。

## Dry-run Impact Report

- Target Issue: #741
- Implementing Success Criteria: Issue comment helper queue を止め、未接続を明示 blocked にする。
- Explicit Non-goals: pagination 修正、VPS live mutation、deploy、credential/permission mutation、Issue close。
- Expected touched files/routes/workflows: Worker Dashboard chat route、VPS helper queue route、passkey operator page、queue docs/tests、generated worker。
- Affected Issues: #741, #637, #413, #450
- Affected PRs: follow-up to PR #823, PR #824, PR #825
- Affected workflows: deploy 後 bridge helper continuation は local queue 未接続として blocked になる。
- Affected runtime/operator surfaces: Dashboard Butler、passkey operator、VPS privileged maintenance helper queue route。
- What may break if we patch narrowly: bridge restart の実行能力は一時的に blocked になる。ただし Issue コメント蓄積と silent drop を止めるため意図した挙動。
- Unknowns to investigate before coding: VPS local queue/state/log transport の実装詳細。
- Validation needed: `node --test test/worker.test.js`; `node --test test/vps-runner-script.test.js`; `npm run build:worker`; `npm test`
- Stop condition: Issue comment transport の延命が必要になる場合。

## Execution Queue Delta

- Queue position before: Issue #816 was `Now` for Dashboard Butler follow-up queue media/UI.
- Preemption decision: ROOT。Issue #741 の helper queue defect は Issue #637 privileged maintenance、Issue #413 runtime truth、Issue #450 app-server path を横断して壊すため preempt する。
- Queue delta: Issue #741 moves to `Now` for this safety slice. Issue #816 moves to `Next` and remains active.
- Why this PR is next: pagination 修正で旧 Issue comment transport を延命すると、コメント蓄積と silent pickup gap が残るため。
- Active Issues not downscoped: Active Issues are not downscoped. #816 / #814 / #811 / #637 remain active and incomplete.

## File / Line Hypotheses

- file: `src/worker/runtime.js`
  - hypothesis: `createVpsPrivilegedMaintenanceHelperExecutionQueue` が valid envelope を GitHub Issue comment create に変換しているため、queue が溜まり続ける。
  - risk if changed narrowly: blocked flow が Dashboard Butler から消えると operator が `unknown` に戻る。
  - validation: worker tests。
  - related Issue: #741
- file: `src/core/passkey-operator-page.js`
  - hypothesis: queued 以外の continuation response を `unknown` 扱いしている。
  - risk if changed narrowly: owner が blocker reason を読めない。
  - validation: worker operator page tests。
  - related Issue: #741

## Hypothesis Retrospective

- expected: Issue comment queue write を止めても Dashboard Butler / operator には blocked reason が残る。
- actual: worker tests confirmed helper continuation, low-risk read/status, and DashboardChatRoom VPS maintenance flows return blocked without GitHub comment creation.
- mismatch: low-risk blocked flow initially fell through to app-server bridge; `shouldDashboardVpsMaintenanceFlowStayInWorker` was updated to keep local queue unavailable blockers in Worker.
- lesson: Issue comment transport blockers must remain visible in the owner surface; otherwise the system silently falls back to the wrong path.
- should become RAG candidate: VPS helper execution queue must not use GitHub Issue comments; use bounded VPS-local queue/state/log and report only result/postmortem to Dashboard/GitHub.

## Verification Evidence

- Unit: `node --test test/worker.test.js` passed: 292 tests pass.
- Unit: `node --test test/vps-runner-script.test.js` passed: 79 tests pass.
- Build: `npm run build:worker` passed.
- Integration: `npm test` passed: 1243 tests, 1242 pass, 1 skipped; self-parity passed; generated-worker check passed.
- E2E: 未実施。merge/deploy 後に passkey operator continuation が Issue コメントを増やさず blocked reason を表示する live check が必要。
- Evidence path/link: `docs/development-strategy/issue-741-stop-issue-comment-helper-queue.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は明示された fallback surface として扱います。
- Owner goal: Issue コメントに VPS helper execution request を溜め続けない。
- Butler entrypoint: `/v2/dashboard/chat/messages`
- Dashboard Butler natural-language path: Dashboard Butler chat entrypoint `/v2/dashboard/chat/messages` で natural-language maintenance intent / passkey continuation は blocked reason を返す。
- Action Schema exposure: 変更なし。
- Runtime path: Worker route は Issue comment queue write を停止し、local queue 未接続を blocked として返す。
- Runner/runtime truth: `queueCommentPosted=false`, `rootExecutionStarted=false`, `helperExecutionStarted=false`。
- Authority boundary: deploy / credential / permission / VPS systemd / root execution は未実施。
- E2E evidence: 未実施。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: merge 後に別途必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate
- AGENTS.md Butler-First Operating Principle
- AGENTS.md Chief Butler Operating Principle
- AGENTS.md Authority Boundary
- AGENTS.md Evidence Discipline
- docs/butler/execution-queue-contract.md

## Out-of-scope but NOT implemented

- VPS local helper queue/state/log writer
- VPS local queue consumer service
- bridge restart execution
- watchdog timer live install/enable
- existing Issue comment cleanup
- Issue #741 close

## Extra changes (if any)

None.
