### PR TITLE
Issue #741 VPS local helper queue handoff

### DIFF
--- a/docs/development-strategy/issue-741-vps-local-helper-queue.md
+++ b/docs/development-strategy/issue-741-vps-local-helper-queue.md
@@ -1,0 +1,142 @@
+# Issue #741 VPS local helper queue / bridge restart strategy
+
+## 完了体験
+
+Dashboard Butler から scoped passkey / deploy approval 済みの bridge restart
+または VPS privileged maintenance request を投げた時、GitHub Issue comment
+を作らず、接続中 app-server bridge が VPS local queue に一回だけ保存する。
+VPS runner は local queue を先に拾い、root-owned helper へ渡し、state と
+log を VPS 上に残す。Dashboard には「queue に入った / 起動した / 完了 /
+失敗 / 未接続で blocked」が runtime truth として返る。
+
+## VTDD 全体で進める部分
+
+- Issue #741 の root blocker 継続。
+- PR #826 で止めた GitHub Issue comment queue の代替 transport を実装する。
+- Issue #637 の privileged maintenance path に必要な local handoff surface を
+  repo-backed にする。
+- Issue #413 の runtime truth は local log/state を evidence source にする。
+
+## 設計
+
+Worker は VPS filesystem に直接書けないため、保存点は接続中
+app-server bridge に限定する。Worker の queue endpoint は
+`DASHBOARD_CHAT_ROOMS` の app-server control を呼び、control payload を
+bridge socket へ送る。bridge は unprivileged user として local queue/state/log
+へ append/write し、必要なら `vtdd-vps-runner.service` wakeup を試す。
+runner は起動時に VPS local pending queue を GitHub Issue comments より前に
+読んで、pending -> running -> completed/failed へ移す。
+
+未接続の場合、Worker は保存先がないため blocked とする。これは正常系では
+なく、Issue #741 / self-healing watchdog の復旧対象である。
+
+## 仮説
+
+- `src/worker/runtime.js` の `/app-server-control` は deploy bridge restart 専用
+  validation なので、local helper queue 用の固定 message type を追加する。
+- `createVpsPrivilegedMaintenanceHelperExecutionQueue` は現在 503 を返している。
+  ここを `DASHBOARD_CHAT_ROOMS` 経由の local queue handoff に変える。
+- `scripts/run-dashboard-app-server-bridge.mjs` は WebSocket control を受けられる
+  ので、enqueue message を処理して local queue に保存できる。
+- `scripts/run-vps-runner.mjs` は Issue comment pickup が先なので、local queue
+  consumer を先に入れないと旧経路依存が残る。
+- 狭く Worker だけを直すと、VPS に保存されず Butler Completion Gate がまた
+  unconnected になる。
+
+## 検証計画
+
+- Unit: Worker queue endpoint が GitHub API を呼ばず、bridge control を送る。
+- Unit: bridge が helper queue enqueue request を local pending/state/log に
+  保存し、wakeup result を返す。
+- Unit: runner が local pending queue を先に拾い、helper 実行後に completed /
+  failed state に移す。
+- Integration: deploy bridge restart control は既存挙動を維持する。
+- Generated worker: `npm run build:worker`。
+- Full local: `npm test`。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: app-server control validation / routing、helper queue
+  endpoint の local queue control 化。risk は Durable Object socket 未接続時の
+  blocked 表現。
+- `scripts/vps-local-helper-queue.mjs`: local queue/state/log の作成、claim、
+  complete/fail、retention prune。risk は file lock の競合。
+- `scripts/run-dashboard-app-server-bridge.mjs`: enqueue control の受信と local
+  queue 書き込み、runner wakeup。risk は detached restart control との混同。
+- `scripts/run-vps-runner.mjs`: local queue consumer を先頭に追加。risk は旧
+  Issue comment queue との互換順序。
+- `test/worker.test.js` / `test/dashboard-app-server-bridge.test.js` /
+  `test/vps-runner-script.test.js`: transport / local state / no GitHub write を検証。
+- `worker.js`: generated artifact。
+- `docs/mvp/active-issue-execution-queue.md`: Now の delta を更新。
+
+## 既に通っている経路
+
+- PR #826 で Worker は GitHub Issue comment queue を作らなくなった。
+- deploy 後 bridge restart は app-server bridge control へ一回限りで送る経路が
+  既にある。
+- bridge は `deploy_bridge_sync_restart_requested` を受け、VPS local log へ
+  起動証跡を残せる。
+- root-owned helper は `sudo -n /usr/local/sbin/vtdd-vps-maintenance-helper
+  --execute --input <file>` の固定 invocation を持つ。
+
+## 未確認の境界
+
+- live VPS の systemd service がこの PR 後の runner script をいつ読むかは
+  deploy / restart approval 後の runtime truth で確認する。
+- disconnected bridge の完全自律復旧は PR #824 watchdog と運用 install 側の
+  evidence が必要で、この PR 単体では live install しない。
+- Dashboard への helper 完了 postback は local state/log evidence を先に通し、
+  owner-facing final report の拡張は必要なら次 PR に分ける。
+
+## 穴が出そうな箇所
+
+- local queue enqueue が毎分 poll log を残すと、Issue comment queue と同じ
+  蓄積問題になる。poll miss はログ化しない。
+- duplicate request を二重実行しない idempotency が必要。
+- runner が local pending と旧 Issue comment queue の両方を拾うと同じ request
+  が重複する可能性がある。local queue を先に拾い、state で claim する。
+- bridge 未接続時に Worker 側へ一時保存すると「どこにも保存しない」方針に
+  反するため、未接続は blocked にする。
+
+## PR 前に確認すること
+
+- GitHub Issue comment 作成 API が helper queue endpoint から呼ばれないこと。
+- queue/state/log path が `$HOME/vtdd-runner/run/vps-helper-queue` と
+  `$HOME/vtdd-runner/logs/vps-helper-queue.log` に限定されること。
+- log retention / state cleanup が設定され、空 poll を記録しないこと。
+- deploy bridge restart 既存 tests が壊れていないこと。
+
+## 実装候補と捨てた案
+
+- 採用: Worker -> connected bridge control -> VPS local queue -> runner pickup。
+- 捨てた案: Worker KV/D1 に queue を保存して VPS が pull する。VPS local 以外に
+  保存が残るため user の方針に反する。
+- 捨てた案: Issue comment pagination を直して延命する。コメント蓄積の根本原因を
+  残す。
+- 捨てた案: bridge が root helper を直接 sudo 実行する。既存 runner/helper
+  boundary を迂回し、authority evidence が分散する。
+
+## merge 後に通す E2E
+
+- deploy 後に bridge control が `queueCommentPosted=false` のまま local queue/log
+  evidence を返す。
+- Butler から passkey approval 後に helper queue enqueue が `queued` を返す。
+- VPS runner が pending local queue を拾い、state が completed または failed に
+  変わる。
+- bridge restart 後も Dashboard main thread の pending owner messages が失われ
+  ない。
+
+## 次の PR を増やさない理由
+
+Issue comment queue を止めた後、local queue producer と consumer を別 PR に
+分けると Butler からの handoff がまた blocked のまま残る。今回の PR は
+producer/control/consumer/local evidence の最小閉路だけを入れ、live deploy /
+watchdog install / Issue close は別 authority 境界に残す。
+
+## 停止条件
+
+- Worker が VPS local 以外に helper execution envelope を永続化する必要が出た時。
+- bridge 未接続時の store-and-forward を入れたくなった時。
+- root helper の sudoers / capability manifest を変更する必要が出た時。
+- deploy、credential、permission、systemd live mutation が必要になった時。

--- a/docs/mvp/active-issue-execution-queue.md
+++ b/docs/mvp/active-issue-execution-queue.md
@@ -191,16 +191,24 @@ Last rebuilt from GitHub runtime truth: 2026-06-05
   延命せず、Issue comment helper queue を止める safety slice が `Now` に
   preempt する。Issue #816 / #814 / #811 は active のまま、#741 safety slice
   の後に再開する。
+- 2026-06-07 PR #826 merged and deployed the safety slice: Worker no longer
+  creates GitHub Issue comment helper queue entries. Owner then requested the
+  next required repair, classified as the same Issue #741 `ROOT` continuation:
+  connect VPS local queue/state/log and runner pickup so Butler can hand off
+  bridge restart / privileged maintenance without storing helper envelopes in
+  GitHub comments or Worker persistence.
 
 ## Now
 
 - Issue #741: GitHub Issue comment を VPS privileged maintenance helper
-  execution queue として使う旧経路を止める。pagination 修正ではなく、
-  Dashboard Butler / passkey operator continuation は Issue comment を作らず
-  `vps_local_helper_queue_unavailable` blocked を返し、root/helper execution
-  を開始しない。これは safety slice であり、VPS local queue/state/log consumer
-  の接続、bridge restart 完了、watchdog live install/enable、Issue #741 close は
-  次 slice に残る。
+  execution queue として使う旧経路を止めた後の継続 slice。Dashboard Butler /
+  passkey operator continuation は Issue comment を作らず、接続中
+  app-server bridge へ VPS local helper queue enqueue control を送り、bridge が
+  VPS local queue/state/log に一回保存し、VPS runner が local pending を GitHub
+  Issue comments より先に pickup する。bridge 未接続時は store-and-forward せず
+  `vps_local_helper_queue_unavailable` blocked として扱い、Worker では
+  root/helper execution を開始しない。watchdog live install/enable、production
+  deploy、Issue #741 close はこの PR では行わない。
 
 ## Next
 

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -8,6 +8,7 @@ import {
   buildDashboardAppServerUsageCostBoundary,
   normalizeDashboardAppServerUsageProfile
 } from "../src/core/dashboard-app-server-usage-profile.js";
+import { enqueueVpsLocalHelperExecution } from "./vps-local-helper-queue.mjs";
 
 const DEFAULT_SCHEMA = "vtdd.dashboard.app_server_bridge.v1";
 const DANGER_FULL_ACCESS_SANDBOX = "danger-full-access";
@@ -618,6 +619,85 @@ export async function executeDeployBridgeSyncRestartRequest({
       reason: normalizeBridgeText(error?.message || "failed to start deploy bridge sync/restart").slice(0, 240)
     };
   }
+}
+
+export async function executeVpsLocalHelperQueueEnqueueRequest({
+  request = {},
+  spawnImpl = spawn,
+  now = () => new Date().toISOString(),
+  enqueue = enqueueVpsLocalHelperExecution
+} = {}) {
+  const startedAt = now();
+  const payload = request?.payload && typeof request.payload === "object" ? request.payload : {};
+  const enqueueResult = await enqueue({
+    payload,
+    queueRoot: process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_DIR,
+    logPath: process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_LOG,
+    now
+  });
+  if (!enqueueResult.ok) {
+    return {
+      type: "vps_local_helper_queue_enqueue_result",
+      schema: DEFAULT_SCHEMA,
+      threadId: normalizeBridgeText(request.threadId),
+      requestId: normalizeBridgeText(request.requestId),
+      executionId: normalizeBridgeText(payload.executionId),
+      repository: normalizeBridgeText(payload.repository),
+      issueNumber: Number(payload.issueNumber || 0) || null,
+      status: "blocked",
+      queued: false,
+      attempted: false,
+      issues: enqueueResult.issues || [enqueueResult.reason || "vps local helper queue enqueue blocked"],
+      startedAt,
+      completedAt: now()
+    };
+  }
+
+  const wakeup = await executeVpsRunnerWakeup({
+    request: {
+      threadId: request.threadId,
+      requestId: `runner-wakeup:${payload.executionId}`,
+      executionId: payload.executionId,
+      repository: payload.repository,
+      issueNumber: payload.issueNumber,
+      queueCommentUrl: ""
+    },
+    spawnImpl,
+    now
+  });
+  return {
+    type: "vps_local_helper_queue_enqueue_result",
+    schema: DEFAULT_SCHEMA,
+    threadId: normalizeBridgeText(request.threadId),
+    requestId: normalizeBridgeText(request.requestId),
+    executionId: normalizeBridgeText(payload.executionId),
+    repository: normalizeBridgeText(payload.repository),
+    issueNumber: Number(payload.issueNumber || 0) || null,
+    dashboardThreadId: normalizeBridgeText(payload.dashboardThreadId || payload?.handoff?.dashboardThreadId),
+    status: enqueueResult.status === "duplicate" ? "duplicate" : "queued",
+    queued: true,
+    attempted: true,
+    queue: {
+      transport: "vps_local_helper_queue",
+      queueFile: enqueueResult.queueFile,
+      stateFile: enqueueResult.stateFile,
+      logPath: enqueueResult.logPath
+    },
+    wakeup: {
+      status: wakeup.status,
+      attempted: wakeup.attempted,
+      fallback: wakeup.fallback,
+      reason: wakeup.reason || null
+    },
+    persistence: {
+      githubIssueCommentQueue: false,
+      vpsLocalQueueFile: enqueueResult.queueFile,
+      vpsLocalStateFile: enqueueResult.stateFile,
+      vpsLocalLogPath: enqueueResult.logPath
+    },
+    startedAt,
+    completedAt: now()
+  };
 }
 
 export function buildDeployBridgeSyncRestartIdempotencyKey(request = {}) {
@@ -2907,6 +2987,9 @@ export async function connectDashboardAppServerBridgeOnce({
     }
     if (payload?.type === "deploy_bridge_sync_restart_requested") {
       executeDeployBridgeSyncRestartRequest({ request: payload }).then((result) => safeSend(result));
+    }
+    if (payload?.type === "vps_local_helper_queue_enqueue_requested") {
+      executeVpsLocalHelperQueueEnqueueRequest({ request: payload }).then((result) => safeSend(result));
     }
   });
 

--- a/scripts/run-vps-runner.mjs
+++ b/scripts/run-vps-runner.mjs
@@ -20,6 +20,11 @@ import {
 import { buildExecutionLeadTime } from "../src/core/execution-lead-time.js";
 import { prepareGuardedPullRequestBody, prepareGuardedPullRequestBodyFile } from "./prepare-pr-body-file.mjs";
 import { renderPrBody } from "./render-pr-body.mjs";
+import {
+  claimNextVpsLocalHelperExecution,
+  completeVpsLocalHelperExecution,
+  peekNextVpsLocalHelperExecution
+} from "./vps-local-helper-queue.mjs";
 
 const QUEUE_MARKER_RE = /<!--\s*vtdd:vps-runner-execution:([a-zA-Z0-9._:-]+)\s*-->/;
 const PRIVILEGED_MAINTENANCE_QUEUE_MARKER_RE =
@@ -131,6 +136,28 @@ async function runVpsRunnerOnce({
         repoSync
       };
     }
+  }
+
+  const localPrivilegedMaintenanceExecution = dryRun
+    ? await peekNextVpsLocalHelperExecution({
+        queueRoot: env.VTDD_VPS_LOCAL_HELPER_QUEUE_DIR,
+        logPath: env.VTDD_VPS_LOCAL_HELPER_QUEUE_LOG
+      })
+    : await claimNextVpsLocalHelperExecution({
+        queueRoot: env.VTDD_VPS_LOCAL_HELPER_QUEUE_DIR,
+        logPath: env.VTDD_VPS_LOCAL_HELPER_QUEUE_LOG
+      });
+  if (localPrivilegedMaintenanceExecution.ok) {
+    if (dryRun) {
+      return {
+        ok: true,
+        message: `Dry run selected local privileged maintenance ${localPrivilegedMaintenanceExecution.payload.executionId} for ${localPrivilegedMaintenanceExecution.payload.repository}#${localPrivilegedMaintenanceExecution.payload.issueNumber}.`
+      };
+    }
+    return executeVpsLocalPrivilegedMaintenanceRunnerExecution({
+      execution: localPrivilegedMaintenanceExecution,
+      env
+    });
   }
 
   const policies = normalizeRepositoryPolicies({ allowedRepositories, repositoryPolicies });
@@ -287,6 +314,64 @@ async function executeVpsPrivilegedMaintenanceRunnerExecution({ githubFetch, exe
     return {
       ok: false,
       reason: "VPS privileged maintenance helper execution failed."
+    };
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function executeVpsLocalPrivilegedMaintenanceRunnerExecution({ execution, env = process.env }) {
+  const payload = { ...execution.payload };
+  const helperPath = normalizeText(payload.executionEnvelope?.helperInvocation?.args?.[1]) ||
+    DEFAULT_PRIVILEGED_MAINTENANCE_HELPER_PATH;
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-helper-execution-"));
+  const inputPath = path.join(tempDir, "helper-execution-input.json");
+  try {
+    await fs.writeFile(inputPath, JSON.stringify(payload.executionEnvelope.helperExecutionInput, null, 2), {
+      mode: 0o600
+    });
+    const result = await runCommand("sudo", ["-n", helperPath, "--execute", "--input", inputPath], {
+      maxBuffer: 1024 * 1024
+    });
+    const parsed = parseJsonObject(result.stdout);
+    await completeVpsLocalHelperExecution({
+      executionId: payload.executionId,
+      status: "completed",
+      result: {
+        rootExecutionStarted: true,
+        helperExecutionStarted: true,
+        runtimeTruth: parsed?.runtimeTruth || null,
+        helperResult: redactVpsPrivilegedMaintenanceHelperResult(parsed)
+      },
+      queueRoot: env.VTDD_VPS_LOCAL_HELPER_QUEUE_DIR,
+      logPath: env.VTDD_VPS_LOCAL_HELPER_QUEUE_LOG
+    });
+    return {
+      ok: true,
+      message: `VPS local privileged maintenance helper execution ${payload.executionId} completed.`
+    };
+  } catch (error) {
+    const parsed = parseJsonObject(error?.stdout);
+    const runtimeTruth = parsed?.runtimeTruth && typeof parsed.runtimeTruth === "object" ? parsed.runtimeTruth : null;
+    await completeVpsLocalHelperExecution({
+      executionId: payload.executionId,
+      status: "failed",
+      result: {
+        rootExecutionStarted: runtimeTruth?.rootExecutionStarted === true,
+        helperExecutionStarted: runtimeTruth?.helperExecutionStarted === true,
+        runtimeTruth,
+        helperResult: redactVpsPrivilegedMaintenanceHelperResult(parsed),
+        rawFailure: {
+          error: "vps_privileged_maintenance_helper_failed",
+          reason: summarizeDiagnosticText(error?.stderr || error?.message || String(error), 500)
+        }
+      },
+      queueRoot: env.VTDD_VPS_LOCAL_HELPER_QUEUE_DIR,
+      logPath: env.VTDD_VPS_LOCAL_HELPER_QUEUE_LOG
+    });
+    return {
+      ok: false,
+      reason: "VPS local privileged maintenance helper execution failed."
     };
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });

--- a/scripts/vps-local-helper-queue.mjs
+++ b/scripts/vps-local-helper-queue.mjs
@@ -1,0 +1,362 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const DEFAULT_QUEUE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_LOG_MAX_BYTES = 1024 * 1024;
+
+export function resolveVpsLocalHelperQueuePaths({
+  queueRoot = process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_DIR,
+  logPath = process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_LOG
+} = {}) {
+  const root = normalizePath(queueRoot) || path.join(os.homedir(), "vtdd-runner", "run", "vps-helper-queue");
+  return {
+    root,
+    pendingDir: path.join(root, "pending"),
+    runningDir: path.join(root, "running"),
+    completedDir: path.join(root, "completed"),
+    failedDir: path.join(root, "failed"),
+    stateDir: path.join(root, "state"),
+    logPath: normalizePath(logPath) || path.join(os.homedir(), "vtdd-runner", "logs", "vps-helper-queue.log")
+  };
+}
+
+export async function enqueueVpsLocalHelperExecution({
+  payload,
+  queueRoot,
+  logPath,
+  now = () => new Date().toISOString()
+} = {}) {
+  const normalized = normalizeVpsLocalHelperExecutionPayload(payload);
+  if (!normalized.ok) {
+    return normalized;
+  }
+  const paths = resolveVpsLocalHelperQueuePaths({ queueRoot, logPath });
+  await ensureQueueDirectories(paths);
+  await pruneVpsLocalHelperQueue({ paths, now });
+
+  const filePath = path.join(paths.pendingDir, `${normalized.payload.executionId}.json`);
+  const statePath = path.join(paths.stateDir, `${normalized.payload.executionId}.json`);
+  if (await fileExists(filePath)) {
+    return {
+      ok: true,
+      status: "duplicate",
+      executionId: normalized.payload.executionId,
+      queueFile: filePath,
+      stateFile: statePath,
+      logPath: paths.logPath
+    };
+  }
+  const queuedAt = now();
+  const record = {
+    ...normalized.payload,
+    lifecycle: {
+      status: "pending",
+      queuedAt,
+      updatedAt: queuedAt
+    }
+  };
+  await writeJsonAtomic(filePath, record, 0o600);
+  await writeJsonAtomic(statePath, summarizeState(record), 0o600);
+  await appendVpsLocalHelperQueueLog({
+    paths,
+    event: "queued",
+    executionId: record.executionId,
+    repository: record.repository,
+    issueNumber: record.issueNumber,
+    dashboardThreadId: record.dashboardThreadId,
+    now
+  });
+  return {
+    ok: true,
+    status: "queued",
+    executionId: record.executionId,
+    queueFile: filePath,
+    stateFile: statePath,
+    logPath: paths.logPath
+  };
+}
+
+export async function claimNextVpsLocalHelperExecution({ queueRoot, logPath, now = () => new Date().toISOString() } = {}) {
+  const paths = resolveVpsLocalHelperQueuePaths({ queueRoot, logPath });
+  await ensureQueueDirectories(paths);
+  const entries = await safeReadDir(paths.pendingDir);
+  const candidates = entries
+    .filter((entry) => entry.endsWith(".json"))
+    .sort((a, b) => a.localeCompare(b));
+  for (const entry of candidates) {
+    const pendingPath = path.join(paths.pendingDir, entry);
+    const executionId = entry.slice(0, -5);
+    const runningPath = path.join(paths.runningDir, entry);
+    try {
+      await fs.rename(pendingPath, runningPath);
+    } catch {
+      continue;
+    }
+    const record = JSON.parse(await fs.readFile(runningPath, "utf8"));
+    const runningAt = now();
+    record.lifecycle = {
+      ...(record.lifecycle || {}),
+      status: "running",
+      runningAt,
+      updatedAt: runningAt
+    };
+    await writeJsonAtomic(runningPath, record, 0o600);
+    const statePath = path.join(paths.stateDir, `${executionId}.json`);
+    await writeJsonAtomic(statePath, summarizeState(record), 0o600);
+    await appendVpsLocalHelperQueueLog({
+      paths,
+      event: "running",
+      executionId,
+      repository: record.repository,
+      issueNumber: record.issueNumber,
+      dashboardThreadId: record.dashboardThreadId,
+      now
+    });
+    return {
+      ok: true,
+      executionId,
+      filePath: runningPath,
+      stateFile: statePath,
+      logPath: paths.logPath,
+      payload: record
+    };
+  }
+  return { ok: false, reason: "no_pending_vps_local_helper_execution" };
+}
+
+export async function peekNextVpsLocalHelperExecution({ queueRoot, logPath } = {}) {
+  const paths = resolveVpsLocalHelperQueuePaths({ queueRoot, logPath });
+  const entries = await safeReadDir(paths.pendingDir);
+  const entry = entries
+    .filter((item) => item.endsWith(".json"))
+    .sort((a, b) => a.localeCompare(b))[0];
+  if (!entry) {
+    return { ok: false, reason: "no_pending_vps_local_helper_execution" };
+  }
+  const payload = await readJsonFile(path.join(paths.pendingDir, entry));
+  if (!payload) {
+    return { ok: false, reason: "vps_local_helper_queue_payload_unreadable" };
+  }
+  return {
+    ok: true,
+    executionId: entry.slice(0, -5),
+    payload
+  };
+}
+
+export async function completeVpsLocalHelperExecution({
+  executionId,
+  status = "completed",
+  result,
+  queueRoot,
+  logPath,
+  now = () => new Date().toISOString()
+} = {}) {
+  const id = safeExecutionId(executionId);
+  if (!id) {
+    return { ok: false, reason: "executionId is required" };
+  }
+  const paths = resolveVpsLocalHelperQueuePaths({ queueRoot, logPath });
+  await ensureQueueDirectories(paths);
+  const sourcePath = path.join(paths.runningDir, `${id}.json`);
+  const targetDir = status === "failed" ? paths.failedDir : paths.completedDir;
+  const targetPath = path.join(targetDir, `${id}.json`);
+  const record = (await readJsonFile(sourcePath)) || { executionId: id };
+  const completedAt = now();
+  record.lifecycle = {
+    ...(record.lifecycle || {}),
+    status,
+    completedAt,
+    updatedAt: completedAt
+  };
+  record.result = result || null;
+  await writeJsonAtomic(sourcePath, record, 0o600);
+  await fs.rename(sourcePath, targetPath).catch(async () => {
+    await writeJsonAtomic(targetPath, record, 0o600);
+  });
+  const statePath = path.join(paths.stateDir, `${id}.json`);
+  await writeJsonAtomic(statePath, summarizeState(record), 0o600);
+  await appendVpsLocalHelperQueueLog({
+    paths,
+    event: status,
+    executionId: id,
+    repository: record.repository,
+    issueNumber: record.issueNumber,
+    dashboardThreadId: record.dashboardThreadId,
+    now
+  });
+  return { ok: true, status, executionId: id, stateFile: statePath, logPath: paths.logPath };
+}
+
+export function normalizeVpsLocalHelperExecutionPayload(payload) {
+  const input = payload && typeof payload === "object" ? payload : {};
+  const executionId = safeExecutionId(input.executionId);
+  const repository = normalizeRepository(input.repository);
+  const issueNumber = normalizePositiveInteger(input.issueNumber);
+  const dashboardThreadId = normalizeText(
+    input.dashboardThreadId || input.dashboard_thread_id || input?.handoff?.dashboardThreadId
+  );
+  const executionEnvelope = input.executionEnvelope && typeof input.executionEnvelope === "object"
+    ? input.executionEnvelope
+    : null;
+  const issues = [];
+  if (!executionId) issues.push("executionId is required");
+  if (!repository) issues.push("repository is required");
+  if (!issueNumber) issues.push("issueNumber is required");
+  if (input.transport !== "vps_privileged_maintenance_helper") {
+    issues.push("transport must be vps_privileged_maintenance_helper");
+  }
+  if (input.approvalScopeMatched !== true) {
+    issues.push("approvalScopeMatched must be true");
+  }
+  if (!executionEnvelope) {
+    issues.push("executionEnvelope is required");
+  }
+  if (executionEnvelope?.kind !== "vps_privileged_maintenance_helper_execution_envelope") {
+    issues.push("executionEnvelope.kind must be vps_privileged_maintenance_helper_execution_envelope");
+  }
+  if (executionEnvelope?.status !== "ready_for_vps_helper_execution") {
+    issues.push("executionEnvelope.status must be ready_for_vps_helper_execution");
+  }
+  if (executionEnvelope?.rootExecutionStarted === true || executionEnvelope?.helperExecutionStarted === true) {
+    issues.push("executionEnvelope must not have started root/helper execution before local queue claim");
+  }
+  if (issues.length > 0) {
+    return { ok: false, status: "blocked", issues };
+  }
+  return {
+    ok: true,
+    payload: {
+      executionId,
+      transport: "vps_privileged_maintenance_helper",
+      repository,
+      issueNumber,
+      dashboardThreadId,
+      approvalActor: normalizeText(input.approvalActor),
+      approvalScopeMatched: true,
+      issueTraceability: input.issueTraceability || null,
+      handoff: dashboardThreadId ? { dashboardThreadId } : null,
+      executionEnvelope
+    }
+  };
+}
+
+async function pruneVpsLocalHelperQueue({
+  paths,
+  ttlMs = Number(process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_TTL_MS) || DEFAULT_QUEUE_TTL_MS,
+  logMaxBytes = Number(process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_LOG_MAX_BYTES) || DEFAULT_LOG_MAX_BYTES,
+  now = () => new Date().toISOString()
+} = {}) {
+  const cutoff = Date.parse(now()) - ttlMs;
+  if (Number.isFinite(cutoff)) {
+    for (const dir of [paths.completedDir, paths.failedDir]) {
+      for (const entry of await safeReadDir(dir)) {
+        const filePath = path.join(dir, entry);
+        const stat = await fs.stat(filePath).catch(() => null);
+        if (stat && stat.mtimeMs < cutoff) {
+          await fs.rm(filePath, { force: true });
+        }
+      }
+    }
+  }
+  const logStat = await fs.stat(paths.logPath).catch(() => null);
+  if (logStat && logStat.size > logMaxBytes) {
+    await fs.rename(paths.logPath, `${paths.logPath}.bak`).catch(() => {});
+  }
+}
+
+async function appendVpsLocalHelperQueueLog({ paths, event, executionId, repository, issueNumber, dashboardThreadId, now }) {
+  await fs.mkdir(path.dirname(paths.logPath), { recursive: true });
+  const line = JSON.stringify({
+    at: now(),
+    event,
+    executionId,
+    repository,
+    issueNumber,
+    dashboardThreadId: dashboardThreadId || null
+  });
+  await fs.appendFile(paths.logPath, `${line}\n`, { mode: 0o600 });
+}
+
+async function ensureQueueDirectories(paths) {
+  await Promise.all([
+    fs.mkdir(paths.pendingDir, { recursive: true }),
+    fs.mkdir(paths.runningDir, { recursive: true }),
+    fs.mkdir(paths.completedDir, { recursive: true }),
+    fs.mkdir(paths.failedDir, { recursive: true }),
+    fs.mkdir(paths.stateDir, { recursive: true }),
+    fs.mkdir(path.dirname(paths.logPath), { recursive: true })
+  ]);
+}
+
+function summarizeState(record) {
+  return {
+    executionId: record.executionId,
+    transport: record.transport,
+    repository: record.repository,
+    issueNumber: record.issueNumber,
+    dashboardThreadId: record.dashboardThreadId || null,
+    capabilityId: record.executionEnvelope?.capabilityId || null,
+    status: record.lifecycle?.status || "unknown",
+    queuedAt: record.lifecycle?.queuedAt || null,
+    runningAt: record.lifecycle?.runningAt || null,
+    completedAt: record.lifecycle?.completedAt || null,
+    updatedAt: record.lifecycle?.updatedAt || null
+  };
+}
+
+async function writeJsonAtomic(filePath, value, mode) {
+  const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tmpPath, JSON.stringify(value, null, 2), { mode });
+  await fs.rename(tmpPath, filePath);
+}
+
+async function readJsonFile(filePath) {
+  try {
+    return JSON.parse(await fs.readFile(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function fileExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function safeReadDir(dir) {
+  try {
+    return await fs.readdir(dir);
+  } catch {
+    return [];
+  }
+}
+
+function normalizeText(value) {
+  return String(value || "").trim();
+}
+
+function normalizePath(value) {
+  const text = normalizeText(value);
+  return text && path.isAbsolute(text) ? text : "";
+}
+
+function normalizeRepository(value) {
+  const text = normalizeText(value);
+  return /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(text) ? text : "";
+}
+
+function normalizePositiveInteger(value) {
+  const number = Number(value);
+  return Number.isInteger(number) && number > 0 ? number : 0;
+}
+
+function safeExecutionId(value) {
+  const text = normalizeText(value);
+  return /^[A-Za-z0-9_.:-]{1,160}$/.test(text) ? text : "";
+}

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -205,15 +205,23 @@ export class DashboardChatRoom {
           reason: "threadId is required"
         });
       }
-      const message = normalizeDeployBridgeControlMessage({
-        threadId,
-        message: payload.message
-      });
+      const rawMessage = payload.message && typeof payload.message === "object" ? payload.message : {};
+      const messageType = normalizeDashboardEventText(rawMessage.type);
+      const message =
+        messageType === "vps_local_helper_queue_enqueue_requested"
+          ? normalizeVpsLocalHelperQueueControlMessage({ threadId, message: rawMessage })
+          : normalizeDeployBridgeControlMessage({
+              threadId,
+              message: rawMessage
+            });
       if (!message.ok) {
         return json(422, {
           ok: false,
-          error: "deploy_bridge_control_invalid",
-          reason: "app-server control only accepts deploy bridge restart requests with fixed target",
+          error:
+            messageType === "vps_local_helper_queue_enqueue_requested"
+              ? "vps_local_helper_queue_control_invalid"
+              : "deploy_bridge_control_invalid",
+          reason: "app-server control only accepts fixed deploy bridge restart or VPS local helper queue requests",
           issues: message.issues
         });
       }
@@ -228,6 +236,7 @@ export class DashboardChatRoom {
             requestId: normalizeDashboardEventText(message.message.requestId),
             messageType: normalizeDashboardEventText(message.message.type),
             deployRunId: normalizeDashboardEventText(message.message.deployRunId),
+            executionId: normalizeDashboardEventText(message.message.executionId),
             idempotencyKey: idempotency.key
           }
         });
@@ -243,7 +252,8 @@ export class DashboardChatRoom {
             reason: "app-server bridge socket is not connected",
             requestId: normalizeDashboardEventText(message.message.requestId),
             messageType: normalizeDashboardEventText(message.message.type),
-            deployRunId: normalizeDashboardEventText(message.message.deployRunId)
+            deployRunId: normalizeDashboardEventText(message.message.deployRunId),
+            executionId: normalizeDashboardEventText(message.message.executionId)
           }
         });
       }
@@ -260,6 +270,7 @@ export class DashboardChatRoom {
           requestId: normalizeDashboardEventText(message.message.requestId),
           messageType: normalizeDashboardEventText(message.message.type),
           deployRunId: normalizeDashboardEventText(message.message.deployRunId),
+          executionId: normalizeDashboardEventText(message.message.executionId),
           idempotencyKey: sent ? idempotency.key : ""
         }
       });
@@ -621,6 +632,10 @@ export class DashboardChatRoom {
       await this.acceptDeployBridgeSyncRestartResult({ socket, attachment, payload });
       return;
     }
+    if (normalizeDashboardEventText(payload?.type).toLowerCase() === "vps_local_helper_queue_enqueue_result") {
+      await this.acceptVpsLocalHelperQueueEnqueueResult({ socket, attachment, payload });
+      return;
+    }
     const normalized = normalizeDashboardAppServerBridgeEvent(payload, {
       fallbackThreadId: attachment?.threadId
     });
@@ -701,6 +716,41 @@ export class DashboardChatRoom {
     if (messagesToAppend.some((message) => shouldClearDashboardTransientProgressSnapshot(message))) {
       await this.clearTransientProgressSnapshot(normalized.threadId);
     }
+    await this.broadcastThread({ threadId: normalized.threadId, messages });
+  }
+
+  async acceptVpsLocalHelperQueueEnqueueResult({ socket, attachment, payload }) {
+    const normalized = normalizeVpsLocalHelperQueueEnqueueResult(payload, {
+      fallbackThreadId: attachment?.threadId
+    });
+    if (!normalized.ok) {
+      this.sendSocket(socket, {
+        type: "error",
+        ok: false,
+        reason: normalized.reason
+      });
+      return;
+    }
+    const attachmentThreadId = normalizeDashboardThreadId(attachment?.threadId);
+    if (attachmentThreadId && normalized.threadId !== attachmentThreadId) {
+      this.sendSocket(socket, {
+        type: "error",
+        ok: false,
+        reason: "VPS local helper queue result threadId does not match the connected dashboard thread"
+      });
+      return;
+    }
+    await this.broadcastTransientStatus({
+      threadId: normalized.threadId,
+      status: normalized.transientStatus,
+      text: normalized.transientText,
+      snapshot: normalized.status === "queued",
+      snapshotSource: "vps_local_helper_queue_enqueue_result"
+    });
+    const store = resolveDashboardChatStore(this.env);
+    const messages = store
+      ? await store.appendMany(normalized.threadId, [normalized.message])
+      : [normalized.message].filter(Boolean);
     await this.broadcastThread({ threadId: normalized.threadId, messages });
   }
 
@@ -5627,6 +5677,55 @@ function normalizeDeployBridgeControlMessage({ threadId, message } = {}) {
   };
 }
 
+function normalizeVpsLocalHelperQueueControlMessage({ threadId, message } = {}) {
+  const issues = [];
+  const source = message && typeof message === "object" ? message : {};
+  const payload = source.payload && typeof source.payload === "object" ? source.payload : {};
+  const normalized = {
+    type: normalizeDashboardEventText(source.type),
+    schema: "vtdd.dashboard.app_server_bridge.v1",
+    requestId: normalizeDashboardEventText(source.requestId),
+    executionId: normalizeDashboardEventText(source.executionId || payload.executionId),
+    threadId: normalizeDashboardThreadId(threadId || source.threadId),
+    repository: normalizeCanonicalRepositoryInput(source.repository || payload.repository),
+    issueNumber: normalizePositiveInteger(source.issueNumber || payload.issueNumber),
+    payload,
+    createdAt: normalizeIsoTimestamp(source.createdAt || source.created_at) || new Date().toISOString()
+  };
+  if (normalized.type !== "vps_local_helper_queue_enqueue_requested") {
+    issues.push("type must be vps_local_helper_queue_enqueue_requested");
+  }
+  if (!normalized.requestId) {
+    issues.push("requestId is required");
+  }
+  if (!normalized.executionId) {
+    issues.push("executionId is required");
+  }
+  if (!normalized.threadId) {
+    issues.push("threadId is required");
+  }
+  if (!normalized.repository) {
+    issues.push("repository is required");
+  }
+  if (!normalized.issueNumber) {
+    issues.push("issueNumber is required");
+  }
+  if (normalizeDashboardEventText(payload.transport) !== "vps_privileged_maintenance_helper") {
+    issues.push("payload.transport must be vps_privileged_maintenance_helper");
+  }
+  if (payload.approvalScopeMatched !== true) {
+    issues.push("payload.approvalScopeMatched must be true");
+  }
+  if (!payload.executionEnvelope || typeof payload.executionEnvelope !== "object") {
+    issues.push("payload.executionEnvelope is required");
+  }
+  return {
+    ok: issues.length === 0,
+    issues,
+    message: normalized
+  };
+}
+
 function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = "" } = {}) {
   const input = normalizeObject(payload);
   const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id || fallbackThreadId);
@@ -5689,6 +5788,129 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
       { threadId }
     )
   };
+}
+
+function normalizeVpsLocalHelperQueueEnqueueResult(payload, { fallbackThreadId = "" } = {}) {
+  const input = normalizeObject(payload);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id || fallbackThreadId);
+  if (!threadId) {
+    return {
+      ok: false,
+      reason: "threadId is required for VPS local helper queue enqueue result"
+    };
+  }
+  const status = normalizeDashboardEventText(input.status).toLowerCase();
+  const allowedStatuses = new Set(["queued", "duplicate", "blocked"]);
+  if (!allowedStatuses.has(status)) {
+    return {
+      ok: false,
+      reason: "VPS local helper queue enqueue result status is invalid"
+    };
+  }
+  const repository = normalizeCanonicalRepositoryInput(input.repository);
+  const issueNumber = normalizePositiveInteger(input.issueNumber || input.issue_number);
+  const executionId = normalizeDashboardEventText(input.executionId || input.execution_id);
+  const requestId = normalizeDashboardEventText(input.requestId || input.request_id);
+  const createdAt = normalizeIsoTimestamp(input.completedAt || input.completed_at || input.createdAt || input.created_at) || new Date().toISOString();
+  const text = buildVpsLocalHelperQueueEnqueueResultMessageText({
+    status,
+    repository,
+    issueNumber,
+    executionId,
+    requestId,
+    queue: input.queue,
+    wakeup: input.wakeup,
+    persistence: input.persistence,
+    issues: input.issues
+  });
+  return {
+    ok: true,
+    threadId,
+    status,
+    repository,
+    issueNumber,
+    executionId,
+    requestId,
+    transientStatus: status === "blocked" ? "failed" : "thinking",
+    transientText:
+      status === "blocked"
+        ? "VPS local helper queue への保存に失敗しました。"
+        : "VPS local helper queue に保存しました。VPS runner が pickup します。",
+    message: normalizeDashboardChatMessage(
+      {
+        threadId,
+        role: "system",
+        repository,
+        relatedIssue: issueNumber || null,
+        status: status === "blocked" ? "failed" : "sent",
+        text,
+        messageId: `vps-local-helper-queue:${executionId || requestId || createDashboardRequestId("queue")}:${status}`,
+        createdAt
+      },
+      { threadId }
+    )
+  };
+}
+
+function buildVpsLocalHelperQueueEnqueueResultMessageText({
+  status = "",
+  repository = "",
+  issueNumber = null,
+  executionId = "",
+  requestId = "",
+  queue = null,
+  wakeup = null,
+  persistence = null,
+  issues = []
+} = {}) {
+  const normalizedQueue = normalizeObject(queue);
+  const normalizedWakeup = normalizeObject(wakeup);
+  const normalizedPersistence = normalizeObject(persistence);
+  const lines = [
+    "VPS local helper queue の保存結果を受信しました。",
+    "",
+    "状態:",
+    `- status: ${status || "unknown"}`,
+    `- repository: ${repository || "未指定"}`,
+    `- relatedIssue: ${issueNumber || "未指定"}`,
+    `- executionId: ${executionId || "未指定"}`,
+    `- requestId: ${requestId || "未指定"}`,
+    "- queueCommentPosted: false",
+    "- transport: vps_local_helper_queue"
+  ];
+  const issueLines = Array.isArray(issues)
+    ? issues.map((issue) => sanitizeDashboardChatText(issue)).filter(Boolean)
+    : [];
+  if (issueLines.length > 0) {
+    lines.push("", "診断:");
+    for (const issue of issueLines.slice(0, 8)) {
+      lines.push(`- ${issue}`);
+    }
+  }
+  const queueFile = sanitizeDashboardChatText(normalizedQueue.queueFile || normalizedPersistence.vpsLocalQueueFile || "");
+  const stateFile = sanitizeDashboardChatText(normalizedQueue.stateFile || normalizedPersistence.vpsLocalStateFile || "");
+  const logPath = sanitizeDashboardChatText(normalizedQueue.logPath || normalizedPersistence.vpsLocalLogPath || "");
+  if (queueFile || stateFile || logPath) {
+    lines.push("", "VPS local evidence:");
+    if (queueFile) lines.push(`- queueFile: ${queueFile}`);
+    if (stateFile) lines.push(`- stateFile: ${stateFile}`);
+    if (logPath) lines.push(`- logPath: ${logPath}`);
+  }
+  if (normalizedWakeup.status || normalizedWakeup.reason) {
+    lines.push("", "runner wakeup:");
+    lines.push(`- status: ${sanitizeDashboardChatText(normalizedWakeup.status || "unknown")}`);
+    lines.push(`- attempted: ${normalizedWakeup.attempted === true ? "true" : "false"}`);
+    if (normalizedWakeup.reason) {
+      lines.push(`- reason: ${sanitizeDashboardChatText(normalizedWakeup.reason)}`);
+    }
+  }
+  if (status === "queued") {
+    lines.push("", "注記: Worker には helper envelope を保存していません。接続中 app-server bridge が VPS local queue/state/log に保存しました。");
+  }
+  if (status === "duplicate") {
+    lines.push("", "注記: 同じ executionId は既に VPS local queue に存在するため、重複保存しません。");
+  }
+  return lines.join("\n");
 }
 
 function buildDeployBridgeSyncRestartResultTransientText({ status = "" } = {}) {
@@ -6684,43 +6906,142 @@ async function createVpsPrivilegedMaintenanceHelperExecutionQueue({ payload, env
       payload?.thread_id
   );
 
+  if (!dashboardThreadId) {
+    const body = {
+      ok: false,
+      error: "vps_local_helper_queue_thread_required",
+      reason: "dashboardThreadId is required so the connected app-server bridge can write the VPS local helper queue.",
+      issues: ["dashboardThreadId is required for VPS local helper queue handoff"],
+      execution: {
+        executionId,
+        transport: "vps_local_helper_queue",
+        repository,
+        issueNumber,
+        dashboardThreadId: null,
+        queueCommentId: null,
+        queueCommentUrl: null,
+        status: "blocked"
+      },
+      runtimeTruth: {
+        kind: "vps_privileged_maintenance_helper_execution_queue",
+        status: "blocked",
+        rootExecutionStarted: false,
+        helperExecutionStarted: false,
+        queueCommentPosted: false,
+        dashboardThreadIdIncluded: false,
+        requiredTransport: "vps_local_helper_queue",
+        disabledTransport: "github_issue_comment_queue"
+      }
+    };
+    return { ok: false, status: 422, error: body.error, reason: body.reason, issues: body.issues, body };
+  }
+
+  const controlMessage = {
+    type: "vps_local_helper_queue_enqueue_requested",
+    schema: "vtdd.dashboard.app_server_bridge.v1",
+    requestId: `vps-local-helper-queue:${executionId}`,
+    executionId,
+    threadId: dashboardThreadId,
+    repository,
+    issueNumber,
+    payload: {
+      executionId,
+      transport: "vps_privileged_maintenance_helper",
+      repository,
+      issueNumber,
+      dashboardThreadId,
+      handoff: { dashboardThreadId },
+      approvalActor: normalizeGitHubLogin(payload?.approvalActor),
+      approvalScopeMatched: true,
+      issueTraceability: {
+        canonicalSpec: "github_issue",
+        issueNumber,
+        relatedIssue: issueNumber,
+        issueTraceable: true
+      },
+      executionEnvelope: envelope
+    },
+    createdAt: new Date().toISOString()
+  };
+  const control = await requestDashboardAppServerBridgeControl({
+    env,
+    threadId: dashboardThreadId,
+    message: controlMessage
+  });
+  if (!control.ok || control.control?.status !== "sent") {
+    const reason = control.reason || control.control?.reason || "app-server bridge socket is not connected";
+    const body = {
+      ok: false,
+      error: "vps_local_helper_queue_unavailable",
+      reason,
+      issues: [
+        "VPS local queue must be written by the connected app-server bridge; Worker does not persist helper envelopes.",
+        reason
+      ],
+      execution: {
+        executionId,
+        transport: "vps_local_helper_queue",
+        repository,
+        issueNumber,
+        dashboardThreadId,
+        queueCommentId: null,
+        queueCommentUrl: null,
+        status: control.control?.status === "duplicate" ? "duplicate" : "blocked"
+      },
+      runtimeTruth: {
+        kind: "vps_privileged_maintenance_helper_execution_queue",
+        status: control.control?.status === "duplicate" ? "vps_local_helper_queue_duplicate" : "vps_local_helper_queue_unavailable",
+        rootExecutionStarted: false,
+        helperExecutionStarted: false,
+        queueCommentPosted: false,
+        dashboardThreadIdIncluded: true,
+        requiredTransport: "vps_local_helper_queue",
+        disabledTransport: "github_issue_comment_queue",
+        bridgeControlSent: false,
+        bridgeControlStatus: control.control?.status || null,
+        nextAction: "Restore the app-server bridge connection and retry; do not create GitHub Issue comment queue entries."
+      }
+    };
+    return {
+      ok: false,
+      status: control.control?.status === "duplicate" ? 202 : 503,
+      error: body.error,
+      reason: body.reason,
+      issues: body.issues,
+      body
+    };
+  }
+
   const body = {
-    ok: false,
-    error: "vps_local_helper_queue_unavailable",
-    reason:
-      "GitHub Issue comments are no longer accepted as the VPS privileged maintenance helper execution queue.",
-    issues: [
-      "Issue comment queue transport is disabled to avoid unbounded comment accumulation and silent pickup gaps.",
-      "A bounded VPS-local helper queue/state/log transport must be connected before this execution can be queued."
-    ],
+    ok: true,
     execution: {
       executionId,
       transport: "vps_local_helper_queue",
       repository,
       issueNumber,
-      dashboardThreadId: dashboardThreadId || null,
+      dashboardThreadId,
       queueCommentId: null,
       queueCommentUrl: null,
-      status: "blocked"
+      status: "sent_to_bridge"
     },
     runtimeTruth: {
       kind: "vps_privileged_maintenance_helper_execution_queue",
-      status: "vps_local_helper_queue_unavailable",
+      status: "vps_local_helper_queue_control_sent",
       rootExecutionStarted: false,
       helperExecutionStarted: false,
       queueCommentPosted: false,
-      dashboardThreadIdIncluded: Boolean(dashboardThreadId),
+      dashboardThreadIdIncluded: true,
       requiredTransport: "vps_local_helper_queue",
       disabledTransport: "github_issue_comment_queue",
-      nextAction: "Connect a bounded VPS-local helper queue/state/log transport before retrying this maintenance execution."
+      bridgeControlSent: true,
+      bridgeControlRequestId: control.control?.requestId || controlMessage.requestId,
+      bridgeControlMessageType: control.control?.messageType || controlMessage.type,
+      nextAction: "Connected app-server bridge will write the VPS local helper queue, state, and log, then wake the VPS runner."
     }
   };
   return {
-    ok: false,
-    status: 503,
-    error: body.error,
-    reason: body.reason,
-    issues: body.issues,
+    ok: true,
+    status: 202,
     body
   };
 }

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -31,6 +31,7 @@ import {
   createDashboardAppServerClientSelector,
   ensureDashboardBridgeRepoSynced,
   executeDeployBridgeSyncRestartRequest,
+  executeVpsLocalHelperQueueEnqueueRequest,
   executeVpsRunnerWakeup,
   extractDashboardAppServerUnsupportedModel,
   extractAppServerNotificationTurnId,
@@ -397,6 +398,82 @@ test("dashboard app-server bridge runner wakeup uses only fixed user systemd sta
   assert.equal(result.fallback, "vtdd-vps-runner.timer");
   assert.equal(result.threadId, "dashboard-main");
   assert.equal(result.executionId, "remote-codex-issue717");
+});
+
+test("dashboard app-server bridge enqueues VPS helper execution into local queue and wakes runner", async () => {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-local-helper-queue-"));
+  const queueRoot = path.join(tmpRoot, "queue");
+  const logPath = path.join(tmpRoot, "logs", "queue.log");
+  const previousQueueRoot = process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_DIR;
+  const previousLogPath = process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_LOG;
+  process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_DIR = queueRoot;
+  process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_LOG = logPath;
+  const spawnCalls = [];
+  try {
+    const result = await executeVpsLocalHelperQueueEnqueueRequest({
+      request: {
+        threadId: "dashboard-main-unresolved",
+        requestId: "vps-local-helper-queue:test",
+        payload: {
+          executionId: "vps-maint-local-741",
+          transport: "vps_privileged_maintenance_helper",
+          repository: "marushu/vtdd-v2-p",
+          issueNumber: 741,
+          dashboardThreadId: "dashboard-main-unresolved",
+          approvalScopeMatched: true,
+          executionEnvelope: {
+            kind: "vps_privileged_maintenance_helper_execution_envelope",
+            status: "ready_for_vps_helper_execution",
+            repository: "marushu/vtdd-v2-p",
+            requestId: "helper-request-741",
+            capabilityId: "dashboard.bridge.unresolved.deploy.sync.restart",
+            mode: "execute",
+            helperInvocation: {
+              executable: "sudo",
+              args: ["-n", "/usr/local/sbin/vtdd-vps-maintenance-helper", "--execute", "--input", "<helper-execution-input-json>"],
+              shell: false,
+              inputFile: "helperExecutionInput"
+            },
+            helperExecutionInput: { mode: "execute", helperRequest: { requestId: "helper-request-741" } },
+            rootExecutionStarted: false,
+            helperExecutionStarted: false
+          }
+        }
+      },
+      now: (() => {
+        const values = ["2026-06-07T01:00:00.000Z", "2026-06-07T01:00:01.000Z", "2026-06-07T01:00:02.000Z"];
+        return () => values.shift() || "2026-06-07T01:00:02.000Z";
+      })(),
+      spawnImpl(command, args, options) {
+        spawnCalls.push({ command, args, options });
+        return {
+          stdout: { on() {} },
+          stderr: { on() {} },
+          on(type, handler) {
+            if (type === "close") queueMicrotask(() => handler(0));
+          }
+        };
+      }
+    });
+
+    assert.equal(result.type, "vps_local_helper_queue_enqueue_result");
+    assert.equal(result.status, "queued");
+    assert.equal(result.persistence.githubIssueCommentQueue, false);
+    assert.equal(result.queue.transport, "vps_local_helper_queue");
+    assert.equal(spawnCalls.length, 1);
+    const pending = JSON.parse(await fs.readFile(path.join(queueRoot, "pending", "vps-maint-local-741.json"), "utf8"));
+    assert.equal(pending.executionId, "vps-maint-local-741");
+    const state = JSON.parse(await fs.readFile(path.join(queueRoot, "state", "vps-maint-local-741.json"), "utf8"));
+    assert.equal(state.status, "pending");
+    const log = await fs.readFile(logPath, "utf8");
+    assert.equal(log.includes('"event":"queued"'), true);
+  } finally {
+    if (previousQueueRoot === undefined) delete process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_DIR;
+    else process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_DIR = previousQueueRoot;
+    if (previousLogPath === undefined) delete process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_LOG;
+    else process.env.VTDD_VPS_LOCAL_HELPER_QUEUE_LOG = previousLogPath;
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  }
 });
 
 test("dashboard app-server bridge deploy restart control uses only fixed sync script", async () => {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -39,6 +39,7 @@ import {
   selectPendingVpsPrivilegedMaintenanceExecutions,
   selectPendingVpsRunnerExecutions
 } from "../scripts/run-vps-runner.mjs";
+import { enqueueVpsLocalHelperExecution } from "../scripts/vps-local-helper-queue.mjs";
 
 function developmentStrategyFixture() {
   return {
@@ -152,6 +153,58 @@ test("VPS runner selects pending privileged maintenance queue only once", () => 
   assert.equal(selected.length, 1);
   assert.equal(selected[0].payload.executionId, "vps-maint-637-c");
   assert.equal(selected[0].actors.queueCommentAuthor, "owner");
+});
+
+test("VPS runner dry-run selects VPS local helper queue before GitHub Issue comments without claiming it", async () => {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-local-runner-"));
+  const queueRoot = path.join(tmpRoot, "queue");
+  await enqueueVpsLocalHelperExecution({
+    queueRoot,
+    payload: {
+      executionId: "vps-maint-local-dry-run",
+      transport: "vps_privileged_maintenance_helper",
+      repository: "sample-org/vtdd-v2",
+      issueNumber: 637,
+      dashboardThreadId: "dashboard-main-sample-org-vtdd-v2",
+      approvalScopeMatched: true,
+      executionEnvelope: {
+        kind: "vps_privileged_maintenance_helper_execution_envelope",
+        status: "ready_for_vps_helper_execution",
+        repository: "sample-org/vtdd-v2",
+        requestId: "helper-request-local",
+        capabilityId: "dashboard.bridge.unresolved.deploy.sync.restart",
+        mode: "execute",
+        helperInvocation: {
+          executable: "sudo",
+          args: ["-n", "/usr/local/sbin/vtdd-vps-maintenance-helper", "--execute", "--input", "<helper-execution-input-json>"],
+          shell: false,
+          inputFile: "helperExecutionInput"
+        },
+        helperExecutionInput: { mode: "execute", helperRequest: { requestId: "helper-request-local" } },
+        rootExecutionStarted: false,
+        helperExecutionStarted: false
+      }
+    },
+    now: () => "2026-06-07T01:00:00.000Z"
+  });
+
+  const result = await runVpsRunnerOnce({
+    githubFetch: async () => [],
+    token: "ghs_test",
+    repositoryPolicies: normalizeRepositoryPolicies({ allowedRepositories: ["sample-org/vtdd-v2"] }),
+    workRoot: path.join(tmpRoot, "work"),
+    dryRun: true,
+    repoSyncPreflight: false,
+    env: {
+      VTDD_VPS_LOCAL_HELPER_QUEUE_DIR: queueRoot
+    }
+  });
+
+  assert.equal(result.ok, true);
+  assert.match(result.message, /Dry run selected local privileged maintenance vps-maint-local-dry-run/);
+  const pending = await fs.readFile(path.join(queueRoot, "pending", "vps-maint-local-dry-run.json"), "utf8");
+  assert.equal(JSON.parse(pending).lifecycle.status, "pending");
+  await fs.rm(tmpRoot, { recursive: true, force: true });
 });
 
 test("VPS runner rejects queue comments without scoped approval", () => {

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -3337,7 +3337,7 @@ test("worker connects VPS privileged maintenance intent from Dashboard Butler ch
   assert.equal(approvedBody.messages[1].role, "butler");
   assert.equal(approvedBody.messages[1].status, "blocked");
   assert.match(approvedBody.messages[1].text, /vps_local_helper_queue_unavailable/);
-  assert.match(approvedBody.messages[1].text, /Issue comment queue transport is disabled/);
+  assert.match(approvedBody.messages[1].text, /Worker does not persist helper envelopes/);
   assert.match(approvedBody.messages[1].text, /rootExecutionStarted=false/);
   assert.equal(githubCalls.length, 0);
 });
@@ -3621,7 +3621,7 @@ test("worker returns blocked VPS continuation execution instead of dropping it",
   assert.equal(body.messages.length, 2);
   assert.equal(body.messages[1].status, "blocked");
   assert.match(body.messages[1].text, /vps_local_helper_queue_unavailable/);
-  assert.match(body.messages[1].text, /Issue comment queue transport is disabled/);
+  assert.match(body.messages[1].text, /Worker does not persist helper envelopes/);
 });
 
 test("worker rejects VPS continuation context that does not match the stored proposal", async () => {
@@ -3832,7 +3832,7 @@ test("worker maps Dashboard Butler VPS runner status text to the low-risk preset
   assert.equal(body.execution.runtimeTruth.rootExecutionStarted, false);
   assert.equal(body.messages[1].status, "blocked");
   assert.match(body.messages[1].text, /vps_local_helper_queue_unavailable/);
-  assert.match(body.messages[1].text, /Issue comment queue transport is disabled/);
+  assert.match(body.messages[1].text, /Worker does not persist helper envelopes/);
   assert.doesNotMatch(body.messages[1].text, /approval URL/);
   assert.equal(githubCalls.length, 0);
 
@@ -12010,6 +12010,7 @@ test("worker dry-runs VPS maintenance helper request without root execution", as
   assert.equal(executionBody.runtimeTruth.helperExecutionStarted, false);
 
   const githubCalls = [];
+  const rooms = createMockDashboardChatRoomNamespace();
   const queueResponse = await worker.fetch(
     new Request("https://example.com/v2/vps/privileged-maintenance/helper-execution-queues", {
       method: "POST",
@@ -12025,6 +12026,7 @@ test("worker dry-runs VPS maintenance helper request without root execution", as
     }),
     {
       ...gatewayAuthEnv,
+      DASHBOARD_CHAT_ROOMS: rooms.namespace,
       GITHUB_APP_INSTALLATION_TOKEN: "ghs_test",
       GITHUB_API_FETCH: async (url, init) => {
         githubCalls.push({ url, init });
@@ -12039,22 +12041,27 @@ test("worker dry-runs VPS maintenance helper request without root execution", as
     }
   );
 
-  assert.equal(queueResponse.status, 503);
+  assert.equal(queueResponse.status, 202);
   const queueBody = await queueResponse.json();
-  assert.equal(queueBody.ok, false);
-  assert.equal(queueBody.error, "vps_local_helper_queue_unavailable");
+  assert.equal(queueBody.ok, true);
   assert.equal(queueBody.execution.executionId, "vps-maint-test-637");
   assert.equal(queueBody.execution.transport, "vps_local_helper_queue");
   assert.equal(queueBody.execution.dashboardThreadId, "dashboard-main-marushu-vtdd-v2-p");
   assert.equal(queueBody.execution.queueCommentId, null);
   assert.equal(queueBody.runtimeTruth.kind, "vps_privileged_maintenance_helper_execution_queue");
-  assert.equal(queueBody.runtimeTruth.status, "vps_local_helper_queue_unavailable");
+  assert.equal(queueBody.runtimeTruth.status, "vps_local_helper_queue_control_sent");
   assert.equal(queueBody.runtimeTruth.dashboardThreadIdIncluded, true);
   assert.equal(queueBody.runtimeTruth.queueCommentPosted, false);
   assert.equal(queueBody.runtimeTruth.disabledTransport, "github_issue_comment_queue");
+  assert.equal(queueBody.runtimeTruth.bridgeControlSent, true);
   assert.equal(queueBody.runtimeTruth.rootExecutionStarted, false);
   assert.equal(queueBody.runtimeTruth.helperExecutionStarted, false);
   assert.equal(githubCalls.length, 0);
+  assert.equal(rooms.calls.length, 1);
+  const controlPayload = JSON.parse(rooms.calls[0].init.body);
+  assert.equal(controlPayload.message.type, "vps_local_helper_queue_enqueue_requested");
+  assert.equal(controlPayload.message.payload.executionId, "vps-maint-test-637");
+  assert.equal(controlPayload.message.payload.executionEnvelope.status, "ready_for_vps_helper_execution");
 });
 
 test("worker retrieves VPS maintenance install inventory without root execution", async () => {

--- a/worker.js
+++ b/worker.js
@@ -58100,15 +58100,17 @@ var DashboardChatRoom = class {
           reason: "threadId is required"
         });
       }
-      const message = normalizeDeployBridgeControlMessage({
+      const rawMessage = payload.message && typeof payload.message === "object" ? payload.message : {};
+      const messageType = normalizeDashboardEventText(rawMessage.type);
+      const message = messageType === "vps_local_helper_queue_enqueue_requested" ? normalizeVpsLocalHelperQueueControlMessage({ threadId: threadId2, message: rawMessage }) : normalizeDeployBridgeControlMessage({
         threadId: threadId2,
-        message: payload.message
+        message: rawMessage
       });
       if (!message.ok) {
         return json(422, {
           ok: false,
-          error: "deploy_bridge_control_invalid",
-          reason: "app-server control only accepts deploy bridge restart requests with fixed target",
+          error: messageType === "vps_local_helper_queue_enqueue_requested" ? "vps_local_helper_queue_control_invalid" : "deploy_bridge_control_invalid",
+          reason: "app-server control only accepts fixed deploy bridge restart or VPS local helper queue requests",
           issues: message.issues
         });
       }
@@ -58123,6 +58125,7 @@ var DashboardChatRoom = class {
             requestId: normalizeDashboardEventText(message.message.requestId),
             messageType: normalizeDashboardEventText(message.message.type),
             deployRunId: normalizeDashboardEventText(message.message.deployRunId),
+            executionId: normalizeDashboardEventText(message.message.executionId),
             idempotencyKey: idempotency.key
           }
         });
@@ -58138,7 +58141,8 @@ var DashboardChatRoom = class {
             reason: "app-server bridge socket is not connected",
             requestId: normalizeDashboardEventText(message.message.requestId),
             messageType: normalizeDashboardEventText(message.message.type),
-            deployRunId: normalizeDashboardEventText(message.message.deployRunId)
+            deployRunId: normalizeDashboardEventText(message.message.deployRunId),
+            executionId: normalizeDashboardEventText(message.message.executionId)
           }
         });
       }
@@ -58155,6 +58159,7 @@ var DashboardChatRoom = class {
           requestId: normalizeDashboardEventText(message.message.requestId),
           messageType: normalizeDashboardEventText(message.message.type),
           deployRunId: normalizeDashboardEventText(message.message.deployRunId),
+          executionId: normalizeDashboardEventText(message.message.executionId),
           idempotencyKey: sent ? idempotency.key : ""
         }
       });
@@ -58490,6 +58495,10 @@ var DashboardChatRoom = class {
       await this.acceptDeployBridgeSyncRestartResult({ socket, attachment, payload });
       return;
     }
+    if (normalizeDashboardEventText(payload?.type).toLowerCase() === "vps_local_helper_queue_enqueue_result") {
+      await this.acceptVpsLocalHelperQueueEnqueueResult({ socket, attachment, payload });
+      return;
+    }
     const normalized = normalizeDashboardAppServerBridgeEvent(payload, {
       fallbackThreadId: attachment?.threadId
     });
@@ -58565,6 +58574,38 @@ var DashboardChatRoom = class {
     if (messagesToAppend.some((message) => shouldClearDashboardTransientProgressSnapshot(message))) {
       await this.clearTransientProgressSnapshot(normalized.threadId);
     }
+    await this.broadcastThread({ threadId: normalized.threadId, messages });
+  }
+  async acceptVpsLocalHelperQueueEnqueueResult({ socket, attachment, payload }) {
+    const normalized = normalizeVpsLocalHelperQueueEnqueueResult(payload, {
+      fallbackThreadId: attachment?.threadId
+    });
+    if (!normalized.ok) {
+      this.sendSocket(socket, {
+        type: "error",
+        ok: false,
+        reason: normalized.reason
+      });
+      return;
+    }
+    const attachmentThreadId = normalizeDashboardThreadId(attachment?.threadId);
+    if (attachmentThreadId && normalized.threadId !== attachmentThreadId) {
+      this.sendSocket(socket, {
+        type: "error",
+        ok: false,
+        reason: "VPS local helper queue result threadId does not match the connected dashboard thread"
+      });
+      return;
+    }
+    await this.broadcastTransientStatus({
+      threadId: normalized.threadId,
+      status: normalized.transientStatus,
+      text: normalized.transientText,
+      snapshot: normalized.status === "queued",
+      snapshotSource: "vps_local_helper_queue_enqueue_result"
+    });
+    const store = resolveDashboardChatStore(this.env);
+    const messages = store ? await store.appendMany(normalized.threadId, [normalized.message]) : [normalized.message].filter(Boolean);
     await this.broadcastThread({ threadId: normalized.threadId, messages });
   }
   async acceptDeployBridgeSyncRestartResult({ socket, attachment, payload }) {
@@ -62886,6 +62927,54 @@ function normalizeDeployBridgeControlMessage({ threadId, message } = {}) {
     message: normalized
   };
 }
+function normalizeVpsLocalHelperQueueControlMessage({ threadId, message } = {}) {
+  const issues = [];
+  const source = message && typeof message === "object" ? message : {};
+  const payload = source.payload && typeof source.payload === "object" ? source.payload : {};
+  const normalized = {
+    type: normalizeDashboardEventText(source.type),
+    schema: "vtdd.dashboard.app_server_bridge.v1",
+    requestId: normalizeDashboardEventText(source.requestId),
+    executionId: normalizeDashboardEventText(source.executionId || payload.executionId),
+    threadId: normalizeDashboardThreadId(threadId || source.threadId),
+    repository: normalizeCanonicalRepositoryInput(source.repository || payload.repository),
+    issueNumber: normalizePositiveInteger10(source.issueNumber || payload.issueNumber),
+    payload,
+    createdAt: normalizeIsoTimestamp(source.createdAt || source.created_at) || (/* @__PURE__ */ new Date()).toISOString()
+  };
+  if (normalized.type !== "vps_local_helper_queue_enqueue_requested") {
+    issues.push("type must be vps_local_helper_queue_enqueue_requested");
+  }
+  if (!normalized.requestId) {
+    issues.push("requestId is required");
+  }
+  if (!normalized.executionId) {
+    issues.push("executionId is required");
+  }
+  if (!normalized.threadId) {
+    issues.push("threadId is required");
+  }
+  if (!normalized.repository) {
+    issues.push("repository is required");
+  }
+  if (!normalized.issueNumber) {
+    issues.push("issueNumber is required");
+  }
+  if (normalizeDashboardEventText(payload.transport) !== "vps_privileged_maintenance_helper") {
+    issues.push("payload.transport must be vps_privileged_maintenance_helper");
+  }
+  if (payload.approvalScopeMatched !== true) {
+    issues.push("payload.approvalScopeMatched must be true");
+  }
+  if (!payload.executionEnvelope || typeof payload.executionEnvelope !== "object") {
+    issues.push("payload.executionEnvelope is required");
+  }
+  return {
+    ok: issues.length === 0,
+    issues,
+    message: normalized
+  };
+}
 function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = "" } = {}) {
   const input = normalizeObject12(payload);
   const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id || fallbackThreadId);
@@ -62948,6 +63037,122 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
       { threadId }
     )
   };
+}
+function normalizeVpsLocalHelperQueueEnqueueResult(payload, { fallbackThreadId = "" } = {}) {
+  const input = normalizeObject12(payload);
+  const threadId = normalizeDashboardThreadId(input.threadId || input.thread_id || fallbackThreadId);
+  if (!threadId) {
+    return {
+      ok: false,
+      reason: "threadId is required for VPS local helper queue enqueue result"
+    };
+  }
+  const status = normalizeDashboardEventText(input.status).toLowerCase();
+  const allowedStatuses = /* @__PURE__ */ new Set(["queued", "duplicate", "blocked"]);
+  if (!allowedStatuses.has(status)) {
+    return {
+      ok: false,
+      reason: "VPS local helper queue enqueue result status is invalid"
+    };
+  }
+  const repository = normalizeCanonicalRepositoryInput(input.repository);
+  const issueNumber = normalizePositiveInteger10(input.issueNumber || input.issue_number);
+  const executionId = normalizeDashboardEventText(input.executionId || input.execution_id);
+  const requestId = normalizeDashboardEventText(input.requestId || input.request_id);
+  const createdAt = normalizeIsoTimestamp(input.completedAt || input.completed_at || input.createdAt || input.created_at) || (/* @__PURE__ */ new Date()).toISOString();
+  const text = buildVpsLocalHelperQueueEnqueueResultMessageText({
+    status,
+    repository,
+    issueNumber,
+    executionId,
+    requestId,
+    queue: input.queue,
+    wakeup: input.wakeup,
+    persistence: input.persistence,
+    issues: input.issues
+  });
+  return {
+    ok: true,
+    threadId,
+    status,
+    repository,
+    issueNumber,
+    executionId,
+    requestId,
+    transientStatus: status === "blocked" ? "failed" : "thinking",
+    transientText: status === "blocked" ? "VPS local helper queue \u3078\u306E\u4FDD\u5B58\u306B\u5931\u6557\u3057\u307E\u3057\u305F\u3002" : "VPS local helper queue \u306B\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002VPS runner \u304C pickup \u3057\u307E\u3059\u3002",
+    message: normalizeDashboardChatMessage(
+      {
+        threadId,
+        role: "system",
+        repository,
+        relatedIssue: issueNumber || null,
+        status: status === "blocked" ? "failed" : "sent",
+        text,
+        messageId: `vps-local-helper-queue:${executionId || requestId || createDashboardRequestId("queue")}:${status}`,
+        createdAt
+      },
+      { threadId }
+    )
+  };
+}
+function buildVpsLocalHelperQueueEnqueueResultMessageText({
+  status = "",
+  repository = "",
+  issueNumber = null,
+  executionId = "",
+  requestId = "",
+  queue = null,
+  wakeup = null,
+  persistence = null,
+  issues = []
+} = {}) {
+  const normalizedQueue = normalizeObject12(queue);
+  const normalizedWakeup = normalizeObject12(wakeup);
+  const normalizedPersistence = normalizeObject12(persistence);
+  const lines = [
+    "VPS local helper queue \u306E\u4FDD\u5B58\u7D50\u679C\u3092\u53D7\u4FE1\u3057\u307E\u3057\u305F\u3002",
+    "",
+    "\u72B6\u614B:",
+    `- status: ${status || "unknown"}`,
+    `- repository: ${repository || "\u672A\u6307\u5B9A"}`,
+    `- relatedIssue: ${issueNumber || "\u672A\u6307\u5B9A"}`,
+    `- executionId: ${executionId || "\u672A\u6307\u5B9A"}`,
+    `- requestId: ${requestId || "\u672A\u6307\u5B9A"}`,
+    "- queueCommentPosted: false",
+    "- transport: vps_local_helper_queue"
+  ];
+  const issueLines = Array.isArray(issues) ? issues.map((issue2) => sanitizeDashboardChatText(issue2)).filter(Boolean) : [];
+  if (issueLines.length > 0) {
+    lines.push("", "\u8A3A\u65AD:");
+    for (const issue2 of issueLines.slice(0, 8)) {
+      lines.push(`- ${issue2}`);
+    }
+  }
+  const queueFile = sanitizeDashboardChatText(normalizedQueue.queueFile || normalizedPersistence.vpsLocalQueueFile || "");
+  const stateFile = sanitizeDashboardChatText(normalizedQueue.stateFile || normalizedPersistence.vpsLocalStateFile || "");
+  const logPath = sanitizeDashboardChatText(normalizedQueue.logPath || normalizedPersistence.vpsLocalLogPath || "");
+  if (queueFile || stateFile || logPath) {
+    lines.push("", "VPS local evidence:");
+    if (queueFile) lines.push(`- queueFile: ${queueFile}`);
+    if (stateFile) lines.push(`- stateFile: ${stateFile}`);
+    if (logPath) lines.push(`- logPath: ${logPath}`);
+  }
+  if (normalizedWakeup.status || normalizedWakeup.reason) {
+    lines.push("", "runner wakeup:");
+    lines.push(`- status: ${sanitizeDashboardChatText(normalizedWakeup.status || "unknown")}`);
+    lines.push(`- attempted: ${normalizedWakeup.attempted === true ? "true" : "false"}`);
+    if (normalizedWakeup.reason) {
+      lines.push(`- reason: ${sanitizeDashboardChatText(normalizedWakeup.reason)}`);
+    }
+  }
+  if (status === "queued") {
+    lines.push("", "\u6CE8\u8A18: Worker \u306B\u306F helper envelope \u3092\u4FDD\u5B58\u3057\u3066\u3044\u307E\u305B\u3093\u3002\u63A5\u7D9A\u4E2D app-server bridge \u304C VPS local queue/state/log \u306B\u4FDD\u5B58\u3057\u307E\u3057\u305F\u3002");
+  }
+  if (status === "duplicate") {
+    lines.push("", "\u6CE8\u8A18: \u540C\u3058 executionId \u306F\u65E2\u306B VPS local queue \u306B\u5B58\u5728\u3059\u308B\u305F\u3081\u3001\u91CD\u8907\u4FDD\u5B58\u3057\u307E\u305B\u3093\u3002");
+  }
+  return lines.join("\n");
 }
 function buildDeployBridgeSyncRestartResultTransientText({ status = "" } = {}) {
   if (status === "launch_started") {
@@ -63827,42 +64032,140 @@ async function createVpsPrivilegedMaintenanceHelperExecutionQueue({ payload, env
   const dashboardThreadId = normalizeText33(
     payload?.handoff?.dashboardThreadId || payload?.dashboardThreadId || payload?.dashboard_thread_id || payload?.threadId || payload?.thread_id
   );
+  if (!dashboardThreadId) {
+    const body2 = {
+      ok: false,
+      error: "vps_local_helper_queue_thread_required",
+      reason: "dashboardThreadId is required so the connected app-server bridge can write the VPS local helper queue.",
+      issues: ["dashboardThreadId is required for VPS local helper queue handoff"],
+      execution: {
+        executionId,
+        transport: "vps_local_helper_queue",
+        repository,
+        issueNumber,
+        dashboardThreadId: null,
+        queueCommentId: null,
+        queueCommentUrl: null,
+        status: "blocked"
+      },
+      runtimeTruth: {
+        kind: "vps_privileged_maintenance_helper_execution_queue",
+        status: "blocked",
+        rootExecutionStarted: false,
+        helperExecutionStarted: false,
+        queueCommentPosted: false,
+        dashboardThreadIdIncluded: false,
+        requiredTransport: "vps_local_helper_queue",
+        disabledTransport: "github_issue_comment_queue"
+      }
+    };
+    return { ok: false, status: 422, error: body2.error, reason: body2.reason, issues: body2.issues, body: body2 };
+  }
+  const controlMessage = {
+    type: "vps_local_helper_queue_enqueue_requested",
+    schema: "vtdd.dashboard.app_server_bridge.v1",
+    requestId: `vps-local-helper-queue:${executionId}`,
+    executionId,
+    threadId: dashboardThreadId,
+    repository,
+    issueNumber,
+    payload: {
+      executionId,
+      transport: "vps_privileged_maintenance_helper",
+      repository,
+      issueNumber,
+      dashboardThreadId,
+      handoff: { dashboardThreadId },
+      approvalActor: normalizeGitHubLogin(payload?.approvalActor),
+      approvalScopeMatched: true,
+      issueTraceability: {
+        canonicalSpec: "github_issue",
+        issueNumber,
+        relatedIssue: issueNumber,
+        issueTraceable: true
+      },
+      executionEnvelope: envelope
+    },
+    createdAt: (/* @__PURE__ */ new Date()).toISOString()
+  };
+  const control = await requestDashboardAppServerBridgeControl({
+    env,
+    threadId: dashboardThreadId,
+    message: controlMessage
+  });
+  if (!control.ok || control.control?.status !== "sent") {
+    const reason = control.reason || control.control?.reason || "app-server bridge socket is not connected";
+    const body2 = {
+      ok: false,
+      error: "vps_local_helper_queue_unavailable",
+      reason,
+      issues: [
+        "VPS local queue must be written by the connected app-server bridge; Worker does not persist helper envelopes.",
+        reason
+      ],
+      execution: {
+        executionId,
+        transport: "vps_local_helper_queue",
+        repository,
+        issueNumber,
+        dashboardThreadId,
+        queueCommentId: null,
+        queueCommentUrl: null,
+        status: control.control?.status === "duplicate" ? "duplicate" : "blocked"
+      },
+      runtimeTruth: {
+        kind: "vps_privileged_maintenance_helper_execution_queue",
+        status: control.control?.status === "duplicate" ? "vps_local_helper_queue_duplicate" : "vps_local_helper_queue_unavailable",
+        rootExecutionStarted: false,
+        helperExecutionStarted: false,
+        queueCommentPosted: false,
+        dashboardThreadIdIncluded: true,
+        requiredTransport: "vps_local_helper_queue",
+        disabledTransport: "github_issue_comment_queue",
+        bridgeControlSent: false,
+        bridgeControlStatus: control.control?.status || null,
+        nextAction: "Restore the app-server bridge connection and retry; do not create GitHub Issue comment queue entries."
+      }
+    };
+    return {
+      ok: false,
+      status: control.control?.status === "duplicate" ? 202 : 503,
+      error: body2.error,
+      reason: body2.reason,
+      issues: body2.issues,
+      body: body2
+    };
+  }
   const body = {
-    ok: false,
-    error: "vps_local_helper_queue_unavailable",
-    reason: "GitHub Issue comments are no longer accepted as the VPS privileged maintenance helper execution queue.",
-    issues: [
-      "Issue comment queue transport is disabled to avoid unbounded comment accumulation and silent pickup gaps.",
-      "A bounded VPS-local helper queue/state/log transport must be connected before this execution can be queued."
-    ],
+    ok: true,
     execution: {
       executionId,
       transport: "vps_local_helper_queue",
       repository,
       issueNumber,
-      dashboardThreadId: dashboardThreadId || null,
+      dashboardThreadId,
       queueCommentId: null,
       queueCommentUrl: null,
-      status: "blocked"
+      status: "sent_to_bridge"
     },
     runtimeTruth: {
       kind: "vps_privileged_maintenance_helper_execution_queue",
-      status: "vps_local_helper_queue_unavailable",
+      status: "vps_local_helper_queue_control_sent",
       rootExecutionStarted: false,
       helperExecutionStarted: false,
       queueCommentPosted: false,
-      dashboardThreadIdIncluded: Boolean(dashboardThreadId),
+      dashboardThreadIdIncluded: true,
       requiredTransport: "vps_local_helper_queue",
       disabledTransport: "github_issue_comment_queue",
-      nextAction: "Connect a bounded VPS-local helper queue/state/log transport before retrying this maintenance execution."
+      bridgeControlSent: true,
+      bridgeControlRequestId: control.control?.requestId || controlMessage.requestId,
+      bridgeControlMessageType: control.control?.messageType || controlMessage.type,
+      nextAction: "Connected app-server bridge will write the VPS local helper queue, state, and log, then wake the VPS runner."
     }
   };
   return {
-    ok: false,
-    status: 503,
-    error: body.error,
-    reason: body.reason,
-    issues: body.issues,
+    ok: true,
+    status: 202,
     body
   };
 }
@@ -63904,6 +64207,10 @@ function validateVpsPrivilegedMaintenanceExecutionEnvelopeForQueue(envelope) {
 }
 function safeIdentifier(value) {
   return String(value || "").replace(/[^A-Za-z0-9_.-]+/g, "_").slice(0, 80) || "execution";
+}
+function normalizeGitHubLogin(value) {
+  const login = normalizeText33(value);
+  return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(login) ? login : "";
 }
 async function handleRetrieveVpsMaintenanceInstallInventoryRequest(url) {
   const inventory = buildVpsPrivilegedMaintenanceInstallInventory({


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #741 の継続 slice として、GitHub Issue comment helper queue を止めた後の VPS local queue/state/log transport を接続する。Worker は helper envelope を永続化せず、接続中 app-server bridge へ enqueue control を送り、bridge が VPS local queue/state/log に保存し、VPS runner が local pending を GitHub Issue comments より先に pickup する。bridge 未接続時は store-and-forward せず blocked にする。

## Satisfied Success Criteria

- deploy 後 bridge restart / VPS helper handoff は GitHub Issue comment queue を作らない。
- Worker は helper envelope を保存せず、接続中 app-server bridge へ bounded control を送る。
- app-server bridge は VPS local queue/state/log に enqueue evidence を残す。
- VPS runner は local pending queue を GitHub Issue comments より先に pickup する。
- local queue は completed / failed TTL prune と log .bak rotation を持ち、empty poll をログ化しない。
- queue / state / log path と runner wakeup status を Dashboard chat message と runtime truth に戻せる。

## Unsatisfied Success Criteria

- production deploy は未実施。
- live VPS local queue pickup / helper execution E2E は未実施。
- live bridge restart 完了は未確認。
- watchdog live install/enable は未実施。
- Issue #741 close は未要求。
- CPU / memory growth threshold restart はこの PR では未実装。
- iPhone / iPad sleep 復帰後の progress recovery E2E は未実施。

## Non-goal violations

None.

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-741-vps-local-helper-queue.md
- 完了体験: Dashboard Butler から scoped approval 済み VPS maintenance を投げると、GitHub Issue comment ではなく VPS local queue/state/log に一回保存され、runner が pickup する。未接続時は blocked として owner-facing に返る。
- VTDD 全体で進める部分: Issue #741 / #637 / #413 の VPS handoff transport を、GitHub Issue comment queue から VPS local evidence に移す。
- 設計: Owner-facing completion design は Dashboard Butler の自然文 VPS maintenance request が app-server bridge control 経由で VPS local queue に保存され、runner pickup truth が返ること。scope は producer/control/consumer/local evidence。authority boundary は Worker と bridge が root/helper execution を開始せず、runner が local claim 後に root-owned helper を呼ぶこと。
- 仮説: 疑っていた failure mode は、Issue comment queue を止めただけでは producer/consumer が未接続で Butler handoff が blocked のまま残ること。Worker は VPS filesystem に直接書けないため、接続中 bridge を local writer にし、runner を local-first pickup にする必要があるという予測。
- 検証計画: Worker control handoff、bridge enqueue/wakeup、runner local dry-run pickup、generated worker、full npm test で検証する。
- 改修見積もり: src/worker/runtime.js, worker.js, scripts/run-dashboard-app-server-bridge.mjs, scripts/run-vps-runner.mjs, scripts/vps-local-helper-queue.mjs, related tests, queue docs を改修する。
- 既に通っている経路: PR #826 で Issue comment queue creation は停止済み。deploy bridge restart control は app-server bridge に一回送る既存経路がある。
- 未確認の境界: live VPS deploy / service restart / helper execution は approval-bound で未実施。Dashboard 完了 postback の live E2E は merge 後に必要。
- 穴が出そうな箇所: bridge 未接続時 store-and-forward、empty poll log spam、duplicate execution、local queue と旧 Issue comment queue の二重 pickup、root helper direct sudo bypass。
- PR 前に確認すること: GitHub comment write 0、queueCommentPosted=false、local queue path bounded、dry-run no-claim、full tests、generated worker を確認する。
- 実装候補と捨てた案: 採用は Worker -> bridge control -> VPS local queue -> runner pickup。捨てた案は Worker KV/D1 queue、Issue comment pagination 延命、bridge direct sudo。
- merge 後に通す E2E: Mapped E2E: Dashboard Butler passkey continuation -> VPS local queue enqueue -> VPS runner local pickup -> completed/failed state/log -> Dashboard postback; deploy 後 bridge control -> queueCommentPosted=false -> pending owner messages preserved。
- 次の PR を増やさない理由: producer だけ / consumer だけに分けると Butler handoff がまた blocked のまま残るため、local producer + consumer の最小閉路を同じ PR に入れる。
- 停止条件: Worker が VPS local 以外へ envelope を永続化する必要が出た時、bridge 未接続 store-and-forward が必要になった時、root/sudoers/capability manifest mutation が必要になった時。

## Dry-run Impact Report

- Target Issue: Issue #741
- Implementing Success Criteria: GitHub Issue comment helper queue を使わない VPS local queue/state/log handoff、bridge control enqueue、runner local pickup、no root/helper execution in Worker。
- Explicit Non-goals: deploy、live VPS privileged execution、credential mutation、permission mutation、repository administration、systemd live install/enable、Issue close、CPU/memory threshold restart。
- Expected touched files/routes/workflows: src/worker/runtime.js, worker.js, scripts/run-dashboard-app-server-bridge.mjs, scripts/run-vps-runner.mjs, scripts/vps-local-helper-queue.mjs, tests, docs/mvp/active-issue-execution-queue.md, strategy file。
- Affected Issues: #741, #637, #413
- Affected PRs: PR #826 の safety slice 後続。PR #823 / #824 の bridge control / watchdog 方針を維持する。
- Affected workflows: No GitHub Actions workflow change。VPS runner script behavior changes local pickup order。
- Affected runtime/operator surfaces: /v2/vps/privileged-maintenance/helper-execution-queues, DashboardChatRoom /app-server-control, app-server bridge WebSocket control, VPS runner local queue pickup。
- What may break if we patch narrowly: Worker だけ直すと VPS local 保存がなく Butler completion gate が unconnected のまま。runner だけ直すと producer がない。bridge だけ直すと helper queue endpoint は blocked のまま。
- Unknowns to investigate before coding: live VPS service が updated runner を読むタイミング、live queue path permission、live helper execution result postback。
- Validation needed: unit / integration / generated worker / full test / merge 後 live E2E。
- Stop condition: store-and-forward persistence outside VPS local、root/sudoers mutation、deploy、credential/permission mutation が必要になる場合。

## Execution Queue Delta

- Queue position before: Issue #741 was Now after PR #826 stopped GitHub Issue comment helper queue; local queue/state/log consumer remained the next required #741 slice.
- Preemption decision: ROOT
- Queue delta: Issue #741 moves from PR #826 safety slice to VPS local queue/state/log producer + consumer connection. Issue #816 / #814 / #811 remain active Next lanes.
- Why this PR is next: without local queue producer/consumer, Butler can request VPS maintenance but cannot complete the handoff after Issue comment storage was disabled.
- Active Issues not downscoped: active Issues are not downscoped, deferred out of scope, or treated as complete by omission.

## File / Line Hypotheses

- file: src/worker/runtime.js
  - hypothesis: helper queue endpoint must call app-server bridge control when dashboardThreadId exists and must return blocked when bridge is unavailable.
  - risk if changed narrowly: Worker might store envelopes outside VPS local or silently reintroduce Issue comment writes.
  - validation: test/worker.test.js
  - related Issue: #741
- file: scripts/run-dashboard-app-server-bridge.mjs
  - hypothesis: bridge is the only safe VPS-local writer available from Worker without adding another external persistence layer.
  - risk if changed narrowly: direct sudo from bridge would bypass runner/helper boundary; no wakeup would leave queue waiting for timer.
  - validation: test/dashboard-app-server-bridge.test.js
  - related Issue: #741
- file: scripts/run-vps-runner.mjs
  - hypothesis: local queue must be read before GitHub Issue comments to avoid returning to old transport.
  - risk if changed narrowly: old comments could be preferred and duplicate or stale executions could run.
  - validation: test/vps-runner-script.test.js
  - related Issue: #741

## Hypothesis Retrospective

- expected: Worker cannot write VPS local files, so connected app-server bridge must be the local writer and runner must consume that local queue first.
- actual: Worker now sends vps_local_helper_queue_enqueue_requested; bridge writes local queue/state/log and wakes runner; runner dry-run selects local queue before comments without claiming; runner execution writes completed/failed local state.
- mismatch: live VPS deploy / pickup / completion postback is not included because it requires deploy / privileged host authority.
- lesson: stopping bad persistence is not enough; producer and consumer must be connected in the same slice or Butler remains blocked.
- should become RAG candidate: VPS helper handoff must use VPS local bounded queue/state/log, never GitHub Issue comments, and bridge unavailable means emergency blocked rather than store-and-forward.

## Verification Evidence

- Unit: node --test test/dashboard-app-server-bridge.test.js passed, 83 tests. node --test test/vps-runner-script.test.js passed, 80 tests. node --test test/worker.test.js passed, 292 tests.
- Integration: npm run build:worker passed. npm test passed, 1245 tests, 1244 pass, 1 skipped. check:self-parity passed. check:generated-worker passed.
- E2E: Not run. Production deploy and live VPS privileged execution require scoped passkey approval.
- Manual: No deploy, no live VPS mutation, no root/helper execution was performed.
- Evidence path/link: test/worker.test.js; test/dashboard-app-server-bridge.test.js; test/vps-runner-script.test.js; docs/development-strategy/issue-741-vps-local-helper-queue.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler
- Fallback surface: mac Codex for this implementation PR only; normal owner operation should be Dashboard Butler -> VPS runner.
- Owner goal: Butler can hand off approved VPS maintenance without GitHub Issue comment accumulation, and VPS local queue/state/log keeps bounded evidence.
- Butler entrypoint: Dashboard Butler natural-language VPS maintenance intent and passkey operator continuation.
- Dashboard Butler natural-language path: Dashboard Butler chat entrypoint: owner writes a natural-language VPS maintenance / bridge restart request, Butler creates or continues the VPS helper request, and the Worker queue endpoint sends app-server bridge local enqueue control when bridge is connected.
- Action Schema exposure: unchanged in this PR; existing route remains the runtime handoff target. Custom GPT Action Schema update is not included.
- Runtime path: /v2/vps/privileged-maintenance/helper-execution-queues -> DashboardChatRoom /app-server-control -> app-server bridge -> scripts/vps-local-helper-queue.mjs -> vtdd-vps-runner.service -> runner local pickup -> root-owned helper.
- Runner/runtime truth: runtime truth includes queueCommentPosted=false, bridge control status, queue/state/log path in bridge result, and local runner completed/failed state.
- Authority boundary: Worker and bridge do not execute root helper. Deploy, credential, permission, systemd live install, and root execution are not performed by this PR.
- E2E evidence: このPRスライスでは未接続。Butler-facing E2E は未実施です。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 不要。

## Related Constitution Rules

- このPRを制約した Constitution rules を記載してください。

## Out-of-scope but NOT implemented

None.

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #741
- Execution ID: Not provided.
- Goal: Not provided.
