### PR TITLE
Issue #741 runner wake を主経路 truth にする

### DIFF
--- a/docs/butler/remote-codex-cli-executor.md
+++ b/docs/butler/remote-codex-cli-executor.md
@@ -325,9 +325,10 @@ infrastructure or embedded in this public/core repository.
 
 ### Immediate Wakeup and Timer Fallback
 
-The systemd timer remains the recovery fallback. Operators should keep
-`vtdd-vps-runner.timer` enabled so a missed wakeup, disconnected bridge, or
-temporary Worker/DO delivery failure does not strand queued work.
+Immediate wakeup is the primary pickup path. Operators should keep
+`vtdd-vps-runner.timer` enabled only as a recovery fallback so a missed wakeup,
+temporary service start failure, or already-local pending queue item does not
+strand queued work.
 
 When Dashboard Butler has a live app-server bridge for the same dashboard
 thread, the Worker can send a bounded `runner_wakeup_requested` message after a
@@ -340,9 +341,11 @@ systemctl --user start vtdd-vps-runner.service
 
 The wakeup request does not carry arbitrary shell, command arguments, sudo,
 root-owned helper input, deploy authority, merge authority, or credential
-mutation authority. It is a latency improvement only. If it fails, the response
-must keep the GitHub queue state as `queued` and report the fallback as
-`vtdd-vps-runner.timer`.
+mutation authority. It is the normal pickup trigger, not an authority grant. If
+it succeeds, runtime truth must show `fallbackUsed=false`. If it fails after the
+queue is already local or GitHub-queued, the response must keep the queue state
+as `queued` and report `fallbackUsed=true`, `fallbackRole=recovery_only`, and
+`fallback=vtdd-vps-runner.timer`.
 
 ## Optional API-backed Runner
 

--- a/docs/development-strategy/issue-741-runner-wake-fallback.md
+++ b/docs/development-strategy/issue-741-runner-wake-fallback.md
@@ -1,0 +1,121 @@
+# Issue #741: runner wake primary / timer fallback
+
+## 完了体験
+
+Dashboard Butler / passkey operator が VPS helper queue を作った直後、connected
+app-server bridge が VPS local queue へ保存し、同じ turn で
+`systemctl --user start vtdd-vps-runner.service` を即時実行する。owner-facing
+runtime truth は「即時 wake が主経路」「timer は未使用の fallback」または
+「即時 wake 失敗、timer fallback 待ち」を明示する。
+
+## VTDD 全体で進める部分
+
+Issue #741 の継続 slice として、PR #827 で接続した VPS local queue/state/log
+handoff の次に、runner pickup の主経路を 1 分 timer ではなく app-server
+bridge 経由の即時 wake に寄せる。Issue #816 / #814 / #811 は active のまま
+だが、この ROOT safety slice が終わるまで再開しない。
+
+## 設計
+
+- `executeVpsRunnerWakeup` は fixed user systemd command だけを実行する。
+- 成功時は `primary: systemd_service_start`、`fallbackUsed: false`、
+  `fallbackRole: recovery_only` を返す。
+- 失敗時または bridge 未接続時だけ `fallbackUsed: true` として
+  `vtdd-vps-runner.timer` を recovery fallback と表示する。
+- Worker / DashboardChatRoom の `/runner-wakeup` と
+  `/app-server-control` 結果表示も同じ語彙に寄せる。
+- timer interval 自体はこの PR では変更しない。実機 systemd mutation は
+  passkey/VPS maintenance 境界であり、この PR は runtime truth と主経路の
+  証明を強化する。
+
+## 仮説
+
+既存コードは wakeup command を実行しているが、レスポンスが常に
+`fallback: vtdd-vps-runner.timer` を含むため、owner-facing には timer が主経路
+のように見える。`scripts/run-dashboard-app-server-bridge.mjs` と
+`src/worker/runtime.js` の result normalization / message builder を直せば、
+local queue enqueue 直後の即時 wake が主経路であることを runtime truth と
+テストで固定できる。
+
+## 検証計画
+
+- Unit: `test/dashboard-app-server-bridge.test.js` で systemd start 成功時に
+  `fallbackUsed=false`、失敗時に `fallbackUsed=true` を確認する。
+- Unit: `test/worker.test.js` で DashboardChatRoom の wakeup request と
+  helper queue result message が primary/fallback を区別することを確認する。
+- Build: `npm run build:worker` で generated worker を更新する。
+- Test: 関連 test を通し、必要なら `npm test` を実行する。
+- Runtime: PR 後の deploy は別途 passkey approval が必要。PR 内では live
+  VPS systemd unit を変更しない。
+
+## 改修見積もり
+
+- `scripts/run-dashboard-app-server-bridge.mjs`: runner wakeup result の truth
+  fields を追加。risk は既存 Issue #717 `vps_runner` wakeup response の互換性。
+- `src/worker/runtime.js`: `/runner-wakeup` と result formatter の primary /
+  fallback 表示を追加。risk は owner-facing message が冗長になること。
+- `test/dashboard-app-server-bridge.test.js`: bridge wake result assertions 追加。
+- `test/worker.test.js`: Worker / DashboardChatRoom wakeup assertions 追加。
+- `docs/butler/remote-codex-cli-executor.md`: timer を recovery fallback と明記。
+- `docs/mvp/active-issue-execution-queue.md`: Now の #741 継続内容を更新。
+
+## 既に通っている経路
+
+- PR #826 で GitHub Issue comment helper queue creation を停止した。
+- PR #827 で VPS local queue/state/log handoff と runner local pickup を追加した。
+- production VPS では `vtdd-dashboard-app-server-bridge-unresolved.service` が
+  active running で、`/home/vtdd-runner/vtdd-runner/run/vps-helper-queue` が存在する。
+
+## 未確認の境界
+
+- deploy 後の production runtime で helper queue job を実投入して即時 wake
+  result を観測する E2E は、この PR merge 後の deploy/passkey approval が必要。
+- `vtdd-vps-runner.timer` の interval 変更は operator runtime mutation なので、
+  この PR では実行しない。
+
+## 穴が出そうな箇所
+
+- `fallback` field を消すと既存 caller が壊れる可能性があるため保持しつつ
+  `fallbackUsed` / `fallbackRole` を追加する。
+- bridge 未接続時は Worker が保存しないため、fallback timer だけでは拾えない。
+  その場合は `vps_local_helper_queue_unavailable` の blocked status が正しい。
+- queue 保存後に wake 失敗した場合は local queue が残るため、timer fallback
+  で拾える。ここだけ fallback を owner-facing に表示する。
+
+## PR 前に確認すること
+
+- PR #827 が merged であること。
+- 新規 branch が `origin/main` から作られていること。
+- Issue #741 が open で、この slice が Success Criteria の bridge lifecycle /
+  owner-facing runtime truth に対応していること。
+
+## 実装候補と捨てた案
+
+- 採用: wake result の truth fields を強化し、timer を recovery-only と明記する。
+- 捨てた案: timer を即座に 5 分へ変更する。これは実機運用 mutation を伴い、
+  wake 主経路の信頼性を証明する前に fallback を弱める。
+- 捨てた案: Worker に queue を保存させる。PR #826/#827 の設計に反し、
+  store-and-forward を Worker 側に戻す。
+
+## merge 後に通す E2E
+
+- deploy passkey approval 後、production deploy を走らせる。
+- Dashboard Butler から VPS helper queue が必要な bounded action を投げ、
+  Dashboard result で `fallbackUsed=false` を確認する。
+- VPS で `journalctl --user -u vtdd-vps-runner.service` と
+  `vps-helper-queue.log` を確認し、queue 保存直後に runner が起動したことを
+  記録する。
+
+## 次の PR を増やさない理由
+
+この slice は PR #827 の handoff 接続に直接続く runtime truth 補強であり、
+別 PR に分けると「local queue はできたが、pickup 主経路が timer なのか wake
+なのか」が owner-facing に曖昧なまま残る。
+
+## 停止条件
+
+- Issue #741 と無関係な runner polling interval 変更、credential mutation、
+  deploy、systemd unit live mutation が必要になった場合は停止する。
+- bridge 未接続時に Worker 側 store-and-forward を入れたくなった場合は停止する。
+- tests が既存 Issue #717 `vps_runner` wakeup 互換性を壊す場合は停止して範囲を
+  再確認する。

--- a/docs/mvp/active-issue-execution-queue.md
+++ b/docs/mvp/active-issue-execution-queue.md
@@ -205,7 +205,11 @@ Last rebuilt from GitHub runtime truth: 2026-06-05
   passkey operator continuation は Issue comment を作らず、接続中
   app-server bridge へ VPS local helper queue enqueue control を送り、bridge が
   VPS local queue/state/log に一回保存し、VPS runner が local pending を GitHub
-  Issue comments より先に pickup する。bridge 未接続時は store-and-forward せず
+  Issue comments より先に pickup する。runner pickup は timer poll を主経路に
+  せず、bridge から `systemctl --user start vtdd-vps-runner.service` を即時
+  wake する。`vtdd-vps-runner.timer` は wake 失敗または既存 pending の
+  recovery fallback として owner-facing runtime truth に明示する。
+  bridge 未接続時は store-and-forward せず
   `vps_local_helper_queue_unavailable` blocked として扱い、Worker では
   root/helper execution を開始しない。watchdog live install/enable、production
   deploy、Issue #741 close はこの PR では行わない。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -387,6 +387,16 @@ export function buildVpsRunnerWakeupCommand() {
   };
 }
 
+function buildVpsRunnerWakeupFallbackTruth({ used = false } = {}) {
+  return {
+    primary: "systemd_user_service_start",
+    primaryCommand: "systemctl --user start vtdd-vps-runner.service",
+    fallback: "vtdd-vps-runner.timer",
+    fallbackRole: "recovery_only",
+    fallbackUsed: used === true
+  };
+}
+
 export async function executeVpsRunnerWakeup({
   request = {},
   spawnImpl = spawn,
@@ -404,6 +414,7 @@ export async function executeVpsRunnerWakeup({
         stdio: ["ignore", "pipe", "pipe"]
       });
     } catch (error) {
+      const fallbackTruth = buildVpsRunnerWakeupFallbackTruth({ used: true });
       resolve({
         type: "runner_wakeup_result",
         schema: DEFAULT_SCHEMA,
@@ -412,7 +423,7 @@ export async function executeVpsRunnerWakeup({
         executionId: normalizeBridgeText(request.executionId),
         status: "failed",
         attempted: true,
-        fallback: "vtdd-vps-runner.timer",
+        ...fallbackTruth,
         command,
         startedAt,
         completedAt: now(),
@@ -428,6 +439,7 @@ export async function executeVpsRunnerWakeup({
       stderr += String(chunk || "");
     });
     child.on("error", (error) => {
+      const fallbackTruth = buildVpsRunnerWakeupFallbackTruth({ used: true });
       resolve({
         type: "runner_wakeup_result",
         schema: DEFAULT_SCHEMA,
@@ -436,7 +448,7 @@ export async function executeVpsRunnerWakeup({
         executionId: normalizeBridgeText(request.executionId),
         status: "failed",
         attempted: true,
-        fallback: "vtdd-vps-runner.timer",
+        ...fallbackTruth,
         command,
         startedAt,
         completedAt: now(),
@@ -447,6 +459,8 @@ export async function executeVpsRunnerWakeup({
     child.on("close", (exitCode) => {
       const normalizedExitCode = Number.isInteger(exitCode) ? exitCode : null;
       const reason = normalizeBridgeText(stderr || stdout);
+      const started = normalizedExitCode === 0;
+      const fallbackTruth = buildVpsRunnerWakeupFallbackTruth({ used: !started });
       resolve({
         type: "runner_wakeup_result",
         schema: DEFAULT_SCHEMA,
@@ -456,9 +470,9 @@ export async function executeVpsRunnerWakeup({
         repository: normalizeBridgeText(request.repository),
         issueNumber: Number(request.issueNumber || 0) || null,
         queueCommentUrl: normalizeBridgeText(request.queueCommentUrl),
-        status: normalizedExitCode === 0 ? "started" : "failed",
+        status: started ? "started" : "failed",
         attempted: true,
-        fallback: "vtdd-vps-runner.timer",
+        ...fallbackTruth,
         command,
         startedAt,
         completedAt: now(),
@@ -686,7 +700,11 @@ export async function executeVpsLocalHelperQueueEnqueueRequest({
     wakeup: {
       status: wakeup.status,
       attempted: wakeup.attempted,
+      primary: wakeup.primary,
+      primaryCommand: wakeup.primaryCommand,
       fallback: wakeup.fallback,
+      fallbackRole: wakeup.fallbackRole,
+      fallbackUsed: wakeup.fallbackUsed,
       reason: wakeup.reason || null
     },
     persistence: {

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -167,7 +167,11 @@ export class DashboardChatRoom {
           wakeup: {
             status: "unavailable",
             attempted: false,
+            primary: "systemd_user_service_start",
+            primaryCommand: "systemctl --user start vtdd-vps-runner.service",
             fallback: "vtdd-vps-runner.timer",
+            fallbackRole: "recovery_only",
+            fallbackUsed: true,
             reason: "app-server bridge socket is not connected"
           }
         });
@@ -189,8 +193,14 @@ export class DashboardChatRoom {
         wakeup: {
           status: sent ? "requested" : "unavailable",
           attempted: sent,
+          primary: "systemd_user_service_start",
+          primaryCommand: "systemctl --user start vtdd-vps-runner.service",
           fallback: "vtdd-vps-runner.timer",
-          reason: sent ? "runner wakeup request sent to app-server bridge" : "failed to send runner wakeup request"
+          fallbackRole: "recovery_only",
+          fallbackUsed: !sent,
+          reason: sent
+            ? "runner wakeup request sent to app-server bridge as the primary pickup path"
+            : "failed to send runner wakeup request; timer remains recovery fallback"
         }
       });
     }
@@ -5900,6 +5910,21 @@ function buildVpsLocalHelperQueueEnqueueResultMessageText({
     lines.push("", "runner wakeup:");
     lines.push(`- status: ${sanitizeDashboardChatText(normalizedWakeup.status || "unknown")}`);
     lines.push(`- attempted: ${normalizedWakeup.attempted === true ? "true" : "false"}`);
+    lines.push(
+      `- primary: ${sanitizeDashboardChatText(normalizedWakeup.primary || "systemd_user_service_start")}`
+    );
+    lines.push(
+      `- primaryCommand: ${sanitizeDashboardChatText(
+        normalizedWakeup.primaryCommand || normalizedWakeup.primary_command || "systemctl --user start vtdd-vps-runner.service"
+      )}`
+    );
+    lines.push(
+      `- fallbackRole: ${sanitizeDashboardChatText(normalizedWakeup.fallbackRole || normalizedWakeup.fallback_role || "recovery_only")}`
+    );
+    lines.push(`- fallbackUsed: ${normalizedWakeup.fallbackUsed === true || normalizedWakeup.fallback_used === true ? "true" : "false"}`);
+    if (normalizedWakeup.fallback) {
+      lines.push(`- fallback: ${sanitizeDashboardChatText(normalizedWakeup.fallback)}`);
+    }
     if (normalizedWakeup.reason) {
       lines.push(`- reason: ${sanitizeDashboardChatText(normalizedWakeup.reason)}`);
     }
@@ -10552,7 +10577,11 @@ async function requestDashboardVpsRunnerWakeup({ env, request, execution } = {})
     return {
       status: "unavailable",
       attempted: false,
+      primary: "systemd_user_service_start",
+      primaryCommand: "systemctl --user start vtdd-vps-runner.service",
       fallback: "vtdd-vps-runner.timer",
+      fallbackRole: "recovery_only",
+      fallbackUsed: true,
       reason: "dashboardThreadId is not available"
     };
   }
@@ -10561,7 +10590,11 @@ async function requestDashboardVpsRunnerWakeup({ env, request, execution } = {})
     return {
       status: "unavailable",
       attempted: false,
+      primary: "systemd_user_service_start",
+      primaryCommand: "systemctl --user start vtdd-vps-runner.service",
       fallback: "vtdd-vps-runner.timer",
+      fallbackRole: "recovery_only",
+      fallbackUsed: true,
       reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
     };
   }
@@ -10583,14 +10616,24 @@ async function requestDashboardVpsRunnerWakeup({ env, request, execution } = {})
     return {
       status: normalizeDashboardEventText(body?.wakeup?.status) || (response.ok ? "requested" : "failed"),
       attempted: body?.wakeup?.attempted === true,
+      primary: normalizeDashboardEventText(body?.wakeup?.primary) || "systemd_user_service_start",
+      primaryCommand:
+        normalizeDashboardEventText(body?.wakeup?.primaryCommand || body?.wakeup?.primary_command) ||
+        "systemctl --user start vtdd-vps-runner.service",
       fallback: normalizeDashboardEventText(body?.wakeup?.fallback) || "vtdd-vps-runner.timer",
+      fallbackRole: normalizeDashboardEventText(body?.wakeup?.fallbackRole || body?.wakeup?.fallback_role) || "recovery_only",
+      fallbackUsed: body?.wakeup?.fallbackUsed === true || body?.wakeup?.fallback_used === true,
       reason: normalizeDashboardEventText(body?.wakeup?.reason) || null
     };
   } catch (error) {
     return {
       status: "failed",
       attempted: true,
+      primary: "systemd_user_service_start",
+      primaryCommand: "systemctl --user start vtdd-vps-runner.service",
       fallback: "vtdd-vps-runner.timer",
+      fallbackRole: "recovery_only",
+      fallbackUsed: true,
       reason: sanitizeDashboardChatText(error?.message || "runner wakeup request failed")
     };
   }

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -395,9 +395,46 @@ test("dashboard app-server bridge runner wakeup uses only fixed user systemd sta
   assert.equal(result.type, "runner_wakeup_result");
   assert.equal(result.status, "started");
   assert.equal(result.attempted, true);
+  assert.equal(result.primary, "systemd_user_service_start");
+  assert.equal(result.primaryCommand, "systemctl --user start vtdd-vps-runner.service");
   assert.equal(result.fallback, "vtdd-vps-runner.timer");
+  assert.equal(result.fallbackRole, "recovery_only");
+  assert.equal(result.fallbackUsed, false);
   assert.equal(result.threadId, "dashboard-main");
   assert.equal(result.executionId, "remote-codex-issue717");
+});
+
+test("dashboard app-server bridge marks runner timer fallback used only when immediate wake fails", async () => {
+  const result = await executeVpsRunnerWakeup({
+    request: {
+      threadId: "dashboard-main",
+      requestId: "runner-wakeup:failed",
+      executionId: "remote-codex-issue741"
+    },
+    now: (() => {
+      const values = ["2026-06-07T00:00:00.000Z", "2026-06-07T00:00:01.000Z"];
+      return () => values.shift() || "2026-06-07T00:00:01.000Z";
+    })(),
+    spawnImpl() {
+      return {
+        stdout: { on() {} },
+        stderr: { on(type, handler) {
+          if (type === "data") queueMicrotask(() => handler("unit start failed"));
+        } },
+        on(type, handler) {
+          if (type === "close") queueMicrotask(() => handler(1));
+        }
+      };
+    }
+  });
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.attempted, true);
+  assert.equal(result.primary, "systemd_user_service_start");
+  assert.equal(result.fallback, "vtdd-vps-runner.timer");
+  assert.equal(result.fallbackRole, "recovery_only");
+  assert.equal(result.fallbackUsed, true);
+  assert.match(result.reason, /unit start failed/);
 });
 
 test("dashboard app-server bridge enqueues VPS helper execution into local queue and wakes runner", async () => {
@@ -460,6 +497,10 @@ test("dashboard app-server bridge enqueues VPS helper execution into local queue
     assert.equal(result.status, "queued");
     assert.equal(result.persistence.githubIssueCommentQueue, false);
     assert.equal(result.queue.transport, "vps_local_helper_queue");
+    assert.equal(result.wakeup.status, "started");
+    assert.equal(result.wakeup.primary, "systemd_user_service_start");
+    assert.equal(result.wakeup.fallbackRole, "recovery_only");
+    assert.equal(result.wakeup.fallbackUsed, false);
     assert.equal(spawnCalls.length, 1);
     const pending = JSON.parse(await fs.readFile(path.join(queueRoot, "pending", "vps-maint-local-741.json"), "utf8"));
     assert.equal(pending.executionId, "vps-maint-local-741");

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -5000,7 +5000,11 @@ test("DashboardChatRoom sends runner wakeup requests only to connected app-serve
   const body = await response.json();
   assert.equal(body.wakeup.status, "requested");
   assert.equal(body.wakeup.attempted, true);
+  assert.equal(body.wakeup.primary, "systemd_user_service_start");
+  assert.equal(body.wakeup.primaryCommand, "systemctl --user start vtdd-vps-runner.service");
   assert.equal(body.wakeup.fallback, "vtdd-vps-runner.timer");
+  assert.equal(body.wakeup.fallbackRole, "recovery_only");
+  assert.equal(body.wakeup.fallbackUsed, false);
   assert.equal(dashboardSocket.sent.length, 0);
   assert.equal(bridgeSocket.sent.length, 1);
   const wakeup = JSON.parse(bridgeSocket.sent[0]);
@@ -10738,8 +10742,12 @@ test("worker dispatches VPS runner execution by posting a bounded queue comment"
                   wakeup: {
                     status: "requested",
                     attempted: true,
+                    primary: "systemd_user_service_start",
+                    primaryCommand: "systemctl --user start vtdd-vps-runner.service",
                     fallback: "vtdd-vps-runner.timer",
-                    reason: "runner wakeup request sent to app-server bridge"
+                    fallbackRole: "recovery_only",
+                    fallbackUsed: false,
+                    reason: "runner wakeup request sent to app-server bridge as the primary pickup path"
                   }
                 }),
                 { status: 202, headers: { "content-type": "application/json" } }
@@ -10792,8 +10800,12 @@ test("worker dispatches VPS runner execution by posting a bounded queue comment"
   assert.deepEqual(body.execution.wakeup, {
     status: "requested",
     attempted: true,
+    primary: "systemd_user_service_start",
+    primaryCommand: "systemctl --user start vtdd-vps-runner.service",
     fallback: "vtdd-vps-runner.timer",
-    reason: "runner wakeup request sent to app-server bridge"
+    fallbackRole: "recovery_only",
+    fallbackUsed: false,
+    reason: "runner wakeup request sent to app-server bridge as the primary pickup path"
   });
   assert.equal(calls.length, 2);
   assert.equal(roomCalls.length, 1);

--- a/worker.js
+++ b/worker.js
@@ -58063,7 +58063,11 @@ var DashboardChatRoom = class {
           wakeup: {
             status: "unavailable",
             attempted: false,
+            primary: "systemd_user_service_start",
+            primaryCommand: "systemctl --user start vtdd-vps-runner.service",
             fallback: "vtdd-vps-runner.timer",
+            fallbackRole: "recovery_only",
+            fallbackUsed: true,
             reason: "app-server bridge socket is not connected"
           }
         });
@@ -58085,8 +58089,12 @@ var DashboardChatRoom = class {
         wakeup: {
           status: sent ? "requested" : "unavailable",
           attempted: sent,
+          primary: "systemd_user_service_start",
+          primaryCommand: "systemctl --user start vtdd-vps-runner.service",
           fallback: "vtdd-vps-runner.timer",
-          reason: sent ? "runner wakeup request sent to app-server bridge" : "failed to send runner wakeup request"
+          fallbackRole: "recovery_only",
+          fallbackUsed: !sent,
+          reason: sent ? "runner wakeup request sent to app-server bridge as the primary pickup path" : "failed to send runner wakeup request; timer remains recovery fallback"
         }
       });
     }
@@ -63142,6 +63150,21 @@ function buildVpsLocalHelperQueueEnqueueResultMessageText({
     lines.push("", "runner wakeup:");
     lines.push(`- status: ${sanitizeDashboardChatText(normalizedWakeup.status || "unknown")}`);
     lines.push(`- attempted: ${normalizedWakeup.attempted === true ? "true" : "false"}`);
+    lines.push(
+      `- primary: ${sanitizeDashboardChatText(normalizedWakeup.primary || "systemd_user_service_start")}`
+    );
+    lines.push(
+      `- primaryCommand: ${sanitizeDashboardChatText(
+        normalizedWakeup.primaryCommand || normalizedWakeup.primary_command || "systemctl --user start vtdd-vps-runner.service"
+      )}`
+    );
+    lines.push(
+      `- fallbackRole: ${sanitizeDashboardChatText(normalizedWakeup.fallbackRole || normalizedWakeup.fallback_role || "recovery_only")}`
+    );
+    lines.push(`- fallbackUsed: ${normalizedWakeup.fallbackUsed === true || normalizedWakeup.fallback_used === true ? "true" : "false"}`);
+    if (normalizedWakeup.fallback) {
+      lines.push(`- fallback: ${sanitizeDashboardChatText(normalizedWakeup.fallback)}`);
+    }
     if (normalizedWakeup.reason) {
       lines.push(`- reason: ${sanitizeDashboardChatText(normalizedWakeup.reason)}`);
     }
@@ -67192,7 +67215,11 @@ async function requestDashboardVpsRunnerWakeup({ env, request, execution } = {})
     return {
       status: "unavailable",
       attempted: false,
+      primary: "systemd_user_service_start",
+      primaryCommand: "systemctl --user start vtdd-vps-runner.service",
       fallback: "vtdd-vps-runner.timer",
+      fallbackRole: "recovery_only",
+      fallbackUsed: true,
       reason: "dashboardThreadId is not available"
     };
   }
@@ -67201,7 +67228,11 @@ async function requestDashboardVpsRunnerWakeup({ env, request, execution } = {})
     return {
       status: "unavailable",
       attempted: false,
+      primary: "systemd_user_service_start",
+      primaryCommand: "systemctl --user start vtdd-vps-runner.service",
       fallback: "vtdd-vps-runner.timer",
+      fallbackRole: "recovery_only",
+      fallbackUsed: true,
       reason: "DASHBOARD_CHAT_ROOMS Durable Object binding is not configured"
     };
   }
@@ -67223,14 +67254,22 @@ async function requestDashboardVpsRunnerWakeup({ env, request, execution } = {})
     return {
       status: normalizeDashboardEventText(body?.wakeup?.status) || (response.ok ? "requested" : "failed"),
       attempted: body?.wakeup?.attempted === true,
+      primary: normalizeDashboardEventText(body?.wakeup?.primary) || "systemd_user_service_start",
+      primaryCommand: normalizeDashboardEventText(body?.wakeup?.primaryCommand || body?.wakeup?.primary_command) || "systemctl --user start vtdd-vps-runner.service",
       fallback: normalizeDashboardEventText(body?.wakeup?.fallback) || "vtdd-vps-runner.timer",
+      fallbackRole: normalizeDashboardEventText(body?.wakeup?.fallbackRole || body?.wakeup?.fallback_role) || "recovery_only",
+      fallbackUsed: body?.wakeup?.fallbackUsed === true || body?.wakeup?.fallback_used === true,
       reason: normalizeDashboardEventText(body?.wakeup?.reason) || null
     };
   } catch (error2) {
     return {
       status: "failed",
       attempted: true,
+      primary: "systemd_user_service_start",
+      primaryCommand: "systemctl --user start vtdd-vps-runner.service",
       fallback: "vtdd-vps-runner.timer",
+      fallbackRole: "recovery_only",
+      fallbackUsed: true,
       reason: sanitizeDashboardChatText(error2?.message || "runner wakeup request failed")
     };
   }


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #741 の継続 slice として、VPS helper queue 保存後の runner pickup を 1 分 timer poll ではなく app-server bridge 経由の即時 wake を主経路として扱う runtime truth に直します。
- Dashboard Butler / passkey operator continuation は GitHub Issue comment queue を作らず、VPS local queue 保存後に `systemctl --user start vtdd-vps-runner.service` を主経路として報告します。
- `vtdd-vps-runner.timer` は通常 pickup ではなく recovery fallback として owner-facing に明示します。

## Satisfied Success Criteria

- Issue #741: deploy / VPS handoff の owner-facing runtime truth で、bridge / runner の before-after と recovery path を区別できる方向へ進めました。
- Issue #741: app-server bridge から fixed non-root runner wake command だけを実行し、成功時は `fallbackUsed=false`、失敗時だけ `fallbackUsed=true` として報告します。
- Issue #741: timer poll を主経路として説明しない docs / active queue truth に更新しました。

## Unsatisfied Success Criteria

- production deploy 後の live VPS helper queue 投入 E2E は未実施です。deploy は scoped passkey approval が必要です。
- Issue #741 全体の bridge lifecycle guard、periodic / health restart、CPU / memory growth detection、iPhone/PWA sleep 復帰 E2E はこの PR では未完了です。
- Issue #741 close はこの PR では行いません。

## Non-goal violations

なし。timer interval 変更、deploy、credential mutation、permission mutation、live systemd unit mutation、Issue close は実行していません。

## 開発前作戦図

- 作戦図 evidence: `docs/development-strategy/issue-741-runner-wake-fallback.md`
- 完了体験: Dashboard Butler / passkey operator が VPS helper queue を作った直後、connected app-server bridge が VPS local queue へ保存し、同じ turn で `systemctl --user start vtdd-vps-runner.service` を即時実行する。owner-facing runtime truth は「即時 wake が主経路」「timer は未使用の fallback」または「即時 wake 失敗、timer fallback 待ち」を明示する。
- VTDD 全体で進める部分: Issue #741 の ROOT safety slice を継続し、PR #827 の VPS local queue/state/log handoff 後に runner pickup の主経路を明確化する。
- 設計: owner-facing scope は Dashboard Butler / passkey operator continuation の runtime truth です。`executeVpsRunnerWakeup` は fixed user systemd command だけを実行し、成功時は `primary=systemd_user_service_start`、`fallbackUsed=false`、失敗時だけ `fallbackUsed=true` を返す。Worker / DashboardChatRoom の result も同じ語彙に寄せる。
- 仮説: 原因仮説は、既存コードが wakeup command を実行していた一方で、レスポンスが常に `fallback=vtdd-vps-runner.timer` を含むため、owner-facing には timer が主経路に見えていたことです。truth fields と表示を直せば、即時 wake が主経路であることを固定できる。
- 検証計画: `test/dashboard-app-server-bridge.test.js`、`test/worker.test.js`、`npm run build:worker`、`npm test` で runtime truth と generated worker を確認する。
- 改修見積もり: `scripts/run-dashboard-app-server-bridge.mjs` は wake result fields、`src/worker/runtime.js` は `/runner-wakeup` と result formatter、`test/*` は assertions、`docs/*` は queue/docs truth、`worker.js` は generated bundle。
- 既に通っている経路: PR #826 で GitHub Issue comment helper queue creation 停止、PR #827 で VPS local queue/state/log handoff と runner local pickup を追加済み。
- 未確認の境界: production helper queue job を実投入して即時 wake result を観測する E2E は merge/deploy 後に必要。`vtdd-vps-runner.timer` interval live mutation は未実施。
- 穴が出そうな箇所: `fallback` field を消すと既存 caller が壊れるため保持し、`fallbackUsed` / `fallbackRole` を追加する。bridge 未接続時は Worker store-and-forward しない。
- PR 前に確認すること: PR #827 merged、最新 `origin/main` から新規 branch、Issue #741 open、関連テストと generated worker。
- 実装候補と捨てた案: 採用は wake result truth fields 強化。捨てた案は timer を即座に 5 分へ変更する案と Worker に queue を保存させる案。
- merge 後に通す E2E: deploy passkey approval 後、production live E2E として helper queue が必要な bounded action を投げ、Dashboard result の `fallbackUsed=false` と VPS journal / queue log を確認する。
- 次の PR を増やさない理由: PR #827 の handoff 接続に直接続く runtime truth 補強であり、分けると pickup 主経路が timer なのか wake なのか曖昧に残る。
- 停止条件: Issue #741 と無関係な runner polling interval 変更、credential mutation、deploy、systemd live mutation、Worker store-and-forward が必要になった場合は停止する。

## Dry-run Impact Report

- Target Issue: Issue #741
- Implementing Success Criteria: bridge restart / VPS helper handoff の owner-facing runtime truth を改善し、runner pickup の主経路を即時 wake として区別する。
- Explicit Non-goals: deploy、credential mutation、permission mutation、destructive cleanup、live systemd unit mutation、timer interval 変更、Issue close。
- Expected touched files/routes/workflows: `scripts/run-dashboard-app-server-bridge.mjs`, `src/worker/runtime.js`, `worker.js`, `test/dashboard-app-server-bridge.test.js`, `test/worker.test.js`, `docs/butler/remote-codex-cli-executor.md`, `docs/mvp/active-issue-execution-queue.md`, `docs/development-strategy/issue-741-runner-wake-fallback.md`
- Affected Issues: Issue #741, related Issue #717 runner wakeup compatibility
- Affected PRs: PR #827 の後続。既存 merged PR には push していません。
- Affected workflows: GitHub Actions test / guarded policy / generated worker check。deploy workflow はこの PR では起動しません。
- Affected runtime/operator surfaces: Dashboard Butler, DashboardChatRoom, app-server bridge, VPS runner wakeup, passkey operator continuation result display
- What may break if we patch narrowly: `fallback` field の互換性を壊すと Issue #717 の `vps_runner` wakeup response が壊れる。bridge 未接続時に fallback を誤表示すると Worker store-and-forward があるように見えてしまう。
- Unknowns to investigate before coding: production helper job の live wake result は merge/deploy 後にだけ観測できる。現 PR では unit test と local runtime truth に限定する。
- Validation needed: targeted node tests、`npm run build:worker`、`npm test`、merge/deploy 後の production VPS E2E
- Stop condition: timer interval や live systemd mutation が必要になったら別 approval 境界へ止める。

## Execution Queue Delta

- Queue position before: Issue #741 は active issue execution queue の Now。PR #827 で local queue/state/log handoff まで進んだ後の継続 slice。
- Preemption decision: ROOT。Issue #741 の helper handoff / bridge lifecycle safety が Issue #637 privileged maintenance、Issue #413 runtime truth、Issue #450 app-server path を横断してブロックするため、Issue #816 / #814 / #811 の前に継続する。
- Queue delta: Issue #741 の `Now` を「VPS local queue handoff」から「runner immediate wake primary / timer recovery fallback truth」へ進める。Issue #816 / #814 / #811 は active のまま再開待ち。
- Why this PR is next: local queue に保存しても runner pickup が 1 分 poll 主経路に見えると、Butler-first の即時 handoff と owner-facing recovery truth が不明確なまま残るため。
- Active Issues not downscoped: Active Issues は縮小しません。この PR で扱わない Issue #816 / #814 / #811 / #741 残 criteria は未完了として残します。

## File / Line Hypotheses

- file: `scripts/run-dashboard-app-server-bridge.mjs`
  - hypothesis: `executeVpsRunnerWakeup` の result が常に `fallback` を返し、fallback 使用有無を区別していない。
  - risk if changed narrowly: `vps_runner` queue wakeup 互換性を壊す。
  - validation: dashboard app-server bridge tests。
  - related Issue: Issue #741 / Issue #717
- file: `src/worker/runtime.js`
  - hypothesis: `/runner-wakeup` と VPS local helper queue result message が timer 主経路に見える表示を作っている。
  - risk if changed narrowly: bridge 未接続時に queue が保存されたように誤読される。
  - validation: worker tests。
  - related Issue: Issue #741
- file: `docs/butler/remote-codex-cli-executor.md`
  - hypothesis: docs が immediate wake を latency improvement として弱く説明している。
  - risk if changed narrowly: operator が 1 分 timer を主経路と誤解する。
  - validation: docs/custom GPT setup tests と PR body evidence。
  - related Issue: Issue #741

## Hypothesis Retrospective

- expected: wakeup success path が `fallbackUsed=false` を返し、failure path が `fallbackUsed=true` を返す。
- actual: `test/dashboard-app-server-bridge.test.js` と `test/worker.test.js` で期待通り通過。
- mismatch: production live helper job E2E は未実施。merge/deploy 後に必要。
- lesson: `fallback` field だけでは主経路と保険の区別が owner-facing に伝わらない。
- should become RAG candidate: yes。`vtdd-vps-runner.timer` は primary pickup ではなく recovery fallback として扱う。

## Verification Evidence

- Unit: `node --test test/dashboard-app-server-bridge.test.js` passed 84 tests; `node --test test/worker.test.js` passed 292 tests; `node --test test/active-issue-execution-queue.test.js test/custom-gpt-setup-docs.test.js` passed 16 tests.
- Integration: `npm run build:worker` passed; `npm test` passed 1245/1246 with 1 skipped, including `check:self-parity` and `check:generated-worker`.
- E2E: 未実施。production deploy と helper queue live wake observation は merge 後に scoped passkey approval が必要。
- Manual: VPS read-only check before implementation confirmed `vtdd-dashboard-app-server-bridge-unresolved.service` active running and `vtdd-vps-runner.timer` exists; no live systemd mutation was performed.
- Evidence path/link: `docs/development-strategy/issue-741-runner-wake-fallback.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler。
- Fallback surface: Custom GPT は fallback surface として扱います。主経路ではありません。
- Owner goal: Butler / passkey operator から VPS helper queue を投げた時、runner pickup が即時 wake 主経路であることを runtime truth で確認できる。
- Butler entrypoint: Dashboard Butler natural-language / passkey operator continuation の既存入口。新しい raw API 入力は要求しません。
- Dashboard Butler natural-language path: Dashboard Butler の通常 chat / VPS maintenance intent から passkey approval 後の helper queue continuation に到達する既存経路を使います。
- Action Schema exposure: 既存 Custom GPT fallback schema は未変更。この PR は Action Schema 追加ではありません。
- Runtime path: Worker `/v2/vps/privileged-maintenance/helper-execution-queues` -> DashboardChatRoom `/app-server-control` -> app-server bridge -> VPS local queue -> `systemctl --user start vtdd-vps-runner.service`。
- Runner/runtime truth: `fallbackUsed=false` on immediate wake success, `fallbackUsed=true` and `fallbackRole=recovery_only` on failure/unavailable.
- Authority boundary: 新しい high-risk authority は追加していません。deploy / credential / permission / live systemd mutation は scoped passkey approval が必要です。
- E2E evidence: 未実施。production deploy 後の live VPS helper queue wake observation が必要です。
- Completion status: incomplete

## Surface Update Checklist

- [x] Dashboard Butler owner-facing runtime truth updated.
- [x] app-server bridge runner wake result updated.
- [x] VPS local helper queue result message updated.
- [x] Tests and generated worker updated.
- [ ] production deploy and live VPS E2E evidence.
- [ ] Issue #741 close readiness.
