### PR TITLE
Issue #741 restart completion truth

### DIFF
--- a/docs/development-strategy/issue-741-restart-completion-truth.md
+++ b/docs/development-strategy/issue-741-restart-completion-truth.md
@@ -1,0 +1,89 @@
+# Issue #741 restart completion truth 作戦図
+
+## 完了体験
+
+Owner が deploy 後 bridge restart を承認したあと、Dashboard Butler は「script を起動しました」だけで止まらず、同じ Dashboard thread に completion truth を返す。最低限、VPS local helper queue に enqueue されたこと、runner wake が試行されたこと、runner が local pending を pickup したこと、restart helper が `synced_and_restarted` / `blocked_*` / `failed` のどれで終わったか、before/after の service state と git SHA を owner-facing に分けて表示できる。
+
+## VTDD 全体で進める部分
+
+Issue #741 の継続 slice として、deploy 後 bridge restart の完了 truth だけを固める。Issue #637 の privileged maintenance boundary と Issue #413 の runtime truth をまたぐが、root/helper 実行の authority model は変えない。Worker は root/helper execution を開始しない。GitHub Issue comment helper queue は復活させない。
+
+## 設計
+
+現在の main は PR #826 で GitHub Issue comment helper queue を停止し、PR #827 / #828 で VPS local helper queue と runner wake を主経路にしている。ただし owner が観測した通り、起動結果と restart 完了結果が混ざると「再起動したのか」が判断できない。今回の設計は、local queue lifecycle と helper result の表現を短く正規化し、completion/failure を Dashboard に戻すための不足を埋める。
+
+Dashboard / Worker 側では `queued` / `wakeup started` を completion と呼ばない。VPS runner 側では local helper queue の `running` / `completed` / `failed` state を必ず更新し、helper script の JSON `runtimeTruth` を state/log に残す。Bridge restart helper script 側では `systemctl restart` 後の service state が before と同じままなら `restart_unverified` として失敗寄りに扱い、単なる exit code 0 を完了扱いしない。
+
+## 仮説
+
+`scripts/sync-dashboard-app-server-bridge-after-deploy.mjs` は `systemctl --user restart` の exit code と after service state を返すが、PID / ActiveEnterTimestamp の変化を completion condition として要求していない。そのため service restart が no-op に見える場合でも `synced_and_restarted` になり得る。また bridge self-launch path は detached log に書くだけなので、Dashboard に completion truth を戻せない。local helper queue path では runner が completion state を書けるため、ここを owner-facing truth の主経路にするのが正しい。
+
+## 検証計画
+
+- Unit: `sync-dashboard-app-server-bridge-after-deploy` が before/after MainPID または ActiveEnterTimestamp の変化を検証し、変化しない場合は `restart_unverified` を返す。
+- Unit: 同 helper が `synced_and_restarted` の時に before/after service state、PID、ActiveEnterTimestamp、git SHA、target ref match を runtimeTruth に含める。
+- Unit: VPS local helper queue completion state が helper result の status/runtimeTruth を state file に残す。
+- Unit: Dashboard app-server bridge の enqueue result は `queued` / `wakeup` を restart completion と混同しない owner-facing fields を持つ。
+- Local: `node --test test/sync-dashboard-app-server-bridge-after-deploy.test.js test/dashboard-app-server-bridge.test.js test/vps-runner-script.test.js --test-name-pattern "bridge|restart|local helper|wakeup|deploy"`
+- Local: `npm run check:generated-worker`。worker source を触る場合は `npm run build:worker` と `npm run verify:worker`。
+
+## 改修見積もり
+
+- `scripts/sync-dashboard-app-server-bridge-after-deploy.mjs`: restart after state verification を追加する。risk は systemd が PID を再利用または timestamp format を返さない環境で false negative になること。
+- `test/sync-dashboard-app-server-bridge-after-deploy.test.js`: success / restart_unverified / dirty checkout の回帰を追加する。risk は fake runner が現実の `systemctl show` とずれること。
+- `scripts/vps-local-helper-queue.mjs`: completion state が result summary を落とさないか確認し、必要なら summarize を拡張する。risk は state file に長い stdout を保存しすぎること。
+- `test/dashboard-app-server-bridge.test.js` または `test/vps-runner-script.test.js`: enqueue/wakeup と completion の用語境界を固定する。risk は既存 owner-facing text の期待値と衝突すること。
+
+## 既に通っている経路
+
+- deploy event から Worker へ通知される。
+- Worker は GitHub Issue comment helper queue を作らない安全 slice を持つ。
+- Dashboard app-server bridge は VPS local helper queue へ enqueue できる。
+- enqueue 後に `systemctl --user start vtdd-vps-runner.service` wake を試行できる。
+- helper script は git sync と `systemctl --user restart vtdd-dashboard-app-server-bridge-unresolved.service` を実行できる。
+
+## 未確認の境界
+
+- production VPS runner が local pending を pickup したあと、Dashboard event endpoint へ completion を安定送信できるか。
+- bridge restart 中に同じ bridge WebSocket が落ちた場合、completion event が再接続後にどの thread へ戻るか。
+- heartbeat file を completion condition に含めるべきかは、現在の helper script 単体では未接続。
+
+## 穴が出そうな箇所
+
+- `systemctl restart` exit code 0 だけで完了扱いすること。
+- detached bridge self-restart log を Dashboard completion と誤解すること。
+- local queue state に result を残しても、Dashboard へ届ける event がないこと。
+- GitHub Issue comment queue を復活させること。
+- restart guard を強くしすぎて正常 restart も `unverified` にすること。
+
+## PR 前に確認すること
+
+- #741 は現在 Now で、#816 / #814 は active のまま downscope しない。
+- root/helper execution, deploy, credential, permission mutation はこの PR で実行しない。
+- production restart E2E は merge/deploy/passkey 後の外部 evidence であり、この PR の local completion とは分ける。
+
+## 実装候補と捨てた案
+
+採用: helper script の completion condition を強め、local queue/result state に owner-facing completion fields を残す。
+
+採用: enqueue/wakeup result の文言を launch truth と completion truth に分離する。
+
+捨てた案: GitHub Issue comment queue を再利用して completion を見せる。PR #826 の安全 slice に反する。
+
+捨てた案: Worker が root/helper execution を直接開始する。authority boundary に反する。
+
+捨てた案: bridge self-restart detached child から completion callback を実装する。self restart 中の connection loss と retry/duplicate guard が広がり、この slice の範囲を超える。
+
+## merge 後に通す E2E
+
+production deploy 後、Dashboard Butler から deploy bridge restart を一回だけ承認し、VPS local helper queue state が `completed` または `failed` に遷移し、Dashboard thread が `script started` ではなく terminal truth を表示することを確認する。成功時は before/after PID または ActiveEnterTimestamp の変化、after git SHA と origin/main SHA の一致を evidence とする。
+
+## 次の PR を増やさない理由
+
+今回の変更は completion 判定と owner-facing truth の不足を同じ failure mode として扱う。helper script だけを直すと Dashboard はまだ launch truth で止まり、Dashboard text だけを直すと helper が no-op restart を成功扱いし続けるため、同じ PR で最低限接続する。
+
+## 停止条件
+
+- restart 完了 after state を検証するには privileged live service 操作が必須で、local/unit で意味のある検証ができない場合。
+- local helper queue から Dashboard completion event へ戻すには新しい credential または permission mutation が必要と判明した場合。
+- restart 中の active turn を壊すリスクが実装中に具体化した場合。

--- a/scripts/run-dashboard-app-server-bridge.mjs
+++ b/scripts/run-dashboard-app-server-bridge.mjs
@@ -707,6 +707,13 @@ export async function executeVpsLocalHelperQueueEnqueueRequest({
       fallbackUsed: wakeup.fallbackUsed,
       reason: wakeup.reason || null
     },
+    restartCompletion: {
+      status: "pending_vps_runner_completion",
+      terminal: false,
+      completionSource: "vps_local_helper_queue_state",
+      stateFile: enqueueResult.stateFile,
+      note: "enqueue and runner wake are launch truth only; restart completion requires local helper queue completed/failed state"
+    },
     persistence: {
       githubIssueCommentQueue: false,
       vpsLocalQueueFile: enqueueResult.queueFile,

--- a/scripts/sync-dashboard-app-server-bridge-after-deploy.mjs
+++ b/scripts/sync-dashboard-app-server-bridge-after-deploy.mjs
@@ -102,6 +102,21 @@ function readServiceState({ cwd, service, runner }) {
   };
 }
 
+function isServiceActive(serviceState = {}) {
+  return serviceState.active === "active" || serviceState.activeState === "active";
+}
+
+function serviceRestartChanged({ beforeService = {}, afterService = {} } = {}) {
+  const beforePid = String(beforeService.mainPid || "");
+  const afterPid = String(afterService.mainPid || "");
+  const beforeEntered = String(beforeService.activeEnterTimestamp || "");
+  const afterEntered = String(afterService.activeEnterTimestamp || "");
+  if (!beforePid && !beforeEntered) {
+    return true;
+  }
+  return Boolean((beforePid && afterPid && beforePid !== afterPid) || (beforeEntered && afterEntered && beforeEntered !== afterEntered));
+}
+
 export async function runDeployBridgeSyncRestart({
   cwd = process.cwd(),
   service = DEFAULT_SERVICE,
@@ -142,6 +157,57 @@ export async function runDeployBridgeSyncRestart({
   const afterGit = readGitState({ cwd, runner });
   const afterService = readServiceState({ cwd, service, runner });
   const afterMatchesTargetRef = Boolean(afterGit.head && afterGit.originMain && afterGit.head === afterGit.originMain);
+  const afterServiceActive = isServiceActive(afterService);
+  const restartVerified = afterServiceActive && serviceRestartChanged({ beforeService, afterService });
+  const commonRuntimeTruth = {
+    kind: "dashboard_bridge_deploy_sync_restart",
+    rootExecutionStarted: false,
+    helperExecutionStarted: true,
+    targetRef: ref,
+    targetRefSha: afterGit.originMain,
+    syncVerified: afterMatchesTargetRef,
+    afterMatchesTargetRef,
+    beforeSha: beforeGit.head,
+    afterSha: afterGit.head,
+    beforeServiceActiveState: beforeService.activeState || beforeService.active,
+    afterServiceActiveState: afterService.activeState || afterService.active,
+    beforeServiceMainPid: beforeService.mainPid,
+    afterServiceMainPid: afterService.mainPid,
+    beforeServiceActiveEnterTimestamp: beforeService.activeEnterTimestamp,
+    afterServiceActiveEnterTimestamp: afterService.activeEnterTimestamp,
+    restartVerified,
+    checkedAt: now()
+  };
+  if (!afterMatchesTargetRef || !restartVerified) {
+    return {
+      ok: false,
+      status: !afterMatchesTargetRef ? "sync_unverified" : "restart_unverified",
+      cwd,
+      service,
+      ref,
+      before: {
+        git: beforeGit,
+        service: beforeService
+      },
+      commands: {
+        fetch,
+        pull,
+        restart
+      },
+      after: {
+        git: afterGit,
+        service: afterService
+      },
+      runtimeTruth: {
+        ...commonRuntimeTruth,
+        status: !afterMatchesTargetRef ? "sync_unverified" : "restart_unverified",
+        serviceRestarted: false,
+        reason: !afterMatchesTargetRef
+          ? "after git HEAD does not match origin/main"
+          : "service restart did not change MainPID or ActiveEnterTimestamp"
+      }
+    };
+  }
   return {
     ok: true,
     status: "synced_and_restarted",
@@ -162,21 +228,10 @@ export async function runDeployBridgeSyncRestart({
       service: afterService
     },
     runtimeTruth: {
-      kind: "dashboard_bridge_deploy_sync_restart",
+      ...commonRuntimeTruth,
       status: "synced_and_restarted",
-      rootExecutionStarted: false,
-      helperExecutionStarted: true,
       serviceRestarted: true,
-      targetRef: ref,
-      targetRefSha: afterGit.originMain,
-      syncVerified: afterMatchesTargetRef,
-      afterMatchesTargetRef,
-      beforeSha: beforeGit.head,
-      afterSha: afterGit.head,
-      beforeServiceActiveState: beforeService.activeState || beforeService.active,
-      afterServiceActiveState: afterService.activeState || afterService.active,
-      afterServiceMainPid: afterService.mainPid,
-      checkedAt: now()
+      restartVerified: true
     }
   };
 }

--- a/scripts/vps-local-helper-queue.mjs
+++ b/scripts/vps-local-helper-queue.mjs
@@ -291,6 +291,7 @@ async function ensureQueueDirectories(paths) {
 }
 
 function summarizeState(record) {
+  const resultSummary = summarizeResult(record.result);
   return {
     executionId: record.executionId,
     transport: record.transport,
@@ -302,8 +303,38 @@ function summarizeState(record) {
     queuedAt: record.lifecycle?.queuedAt || null,
     runningAt: record.lifecycle?.runningAt || null,
     completedAt: record.lifecycle?.completedAt || null,
-    updatedAt: record.lifecycle?.updatedAt || null
+    updatedAt: record.lifecycle?.updatedAt || null,
+    result: resultSummary
   };
+}
+
+function summarizeResult(result) {
+  if (!result || typeof result !== "object") {
+    return null;
+  }
+  const runtimeTruth = result.runtimeTruth && typeof result.runtimeTruth === "object" ? result.runtimeTruth : {};
+  const helperResult = result.helperResult && typeof result.helperResult === "object" ? result.helperResult : {};
+  const rawFailure = result.rawFailure && typeof result.rawFailure === "object" ? result.rawFailure : {};
+  const summary = {
+    rootExecutionStarted: result.rootExecutionStarted === true,
+    helperExecutionStarted: result.helperExecutionStarted === true,
+    runtimeStatus: normalizeText(runtimeTruth.status),
+    helperStatus: normalizeText(helperResult.status),
+    serviceRestarted: runtimeTruth.serviceRestarted === true,
+    restartVerified: runtimeTruth.restartVerified === true,
+    syncVerified: runtimeTruth.syncVerified === true,
+    beforeSha: normalizeText(runtimeTruth.beforeSha),
+    afterSha: normalizeText(runtimeTruth.afterSha),
+    targetRefSha: normalizeText(runtimeTruth.targetRefSha),
+    beforeServiceMainPid: normalizeText(runtimeTruth.beforeServiceMainPid),
+    afterServiceMainPid: normalizeText(runtimeTruth.afterServiceMainPid),
+    beforeServiceActiveEnterTimestamp: normalizeText(runtimeTruth.beforeServiceActiveEnterTimestamp),
+    afterServiceActiveEnterTimestamp: normalizeText(runtimeTruth.afterServiceActiveEnterTimestamp),
+    failureReason: normalizeText(runtimeTruth.reason || rawFailure.reason)
+  };
+  return Object.fromEntries(
+    Object.entries(summary).filter(([, value]) => value !== "" && value !== null && value !== false)
+  );
 }
 
 async function writeJsonAtomic(filePath, value, mode) {

--- a/test/dashboard-app-server-bridge.test.js
+++ b/test/dashboard-app-server-bridge.test.js
@@ -501,11 +501,15 @@ test("dashboard app-server bridge enqueues VPS helper execution into local queue
     assert.equal(result.wakeup.primary, "systemd_user_service_start");
     assert.equal(result.wakeup.fallbackRole, "recovery_only");
     assert.equal(result.wakeup.fallbackUsed, false);
+    assert.equal(result.restartCompletion.status, "pending_vps_runner_completion");
+    assert.equal(result.restartCompletion.terminal, false);
+    assert.equal(result.restartCompletion.completionSource, "vps_local_helper_queue_state");
     assert.equal(spawnCalls.length, 1);
     const pending = JSON.parse(await fs.readFile(path.join(queueRoot, "pending", "vps-maint-local-741.json"), "utf8"));
     assert.equal(pending.executionId, "vps-maint-local-741");
     const state = JSON.parse(await fs.readFile(path.join(queueRoot, "state", "vps-maint-local-741.json"), "utf8"));
     assert.equal(state.status, "pending");
+    assert.equal(state.result, null);
     const log = await fs.readFile(logPath, "utf8");
     assert.equal(log.includes('"event":"queued"'), true);
   } finally {

--- a/test/sync-dashboard-app-server-bridge-after-deploy.test.js
+++ b/test/sync-dashboard-app-server-bridge-after-deploy.test.js
@@ -2,9 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { runDeployBridgeSyncRestart } from "../scripts/sync-dashboard-app-server-bridge-after-deploy.mjs";
 
-function createFakeRunner({ dirty = false } = {}) {
+function createFakeRunner({ dirty = false, restartChangesService = true } = {}) {
   const calls = [];
   let head = "before-sha";
+  let restarted = false;
   const runner = (command, args) => {
     calls.push([command, ...args]);
     const joined = [command, ...args].join(" ");
@@ -32,7 +33,13 @@ function createFakeRunner({ dirty = false } = {}) {
     ) {
       return {
         status: 0,
-        stdout: "ActiveState=active\nSubState=running\nMainPID=1234\nExecMainStatus=0\nActiveEnterTimestamp=Thu 2026-06-04 15:00:46 JST\n",
+        stdout: [
+          "ActiveState=active",
+          "SubState=running",
+          `MainPID=${restarted && restartChangesService ? "5678" : "1234"}`,
+          "ExecMainStatus=0",
+          `ActiveEnterTimestamp=${restarted && restartChangesService ? "Thu 2026-06-04 18:23:12 JST" : "Thu 2026-06-04 15:00:46 JST"}`
+        ].join("\n") + "\n",
         stderr: ""
       };
     }
@@ -44,6 +51,7 @@ function createFakeRunner({ dirty = false } = {}) {
       return { status: 0, stdout: "Fast-forward\n", stderr: "" };
     }
     if (joined === "systemctl --user restart vtdd-dashboard-app-server-bridge-unresolved.service") {
+      restarted = true;
       return { status: 0, stdout: "", stderr: "" };
     }
     return { status: 127, stdout: "", stderr: `unexpected command: ${joined}` };
@@ -69,10 +77,34 @@ test("deploy bridge sync/restart helper fast-forwards checkout and restarts unre
   assert.equal(result.runtimeTruth.targetRefSha, "after-sha");
   assert.equal(result.runtimeTruth.syncVerified, true);
   assert.equal(result.runtimeTruth.afterMatchesTargetRef, true);
-  assert.equal(result.runtimeTruth.afterServiceMainPid, "1234");
+  assert.equal(result.runtimeTruth.restartVerified, true);
+  assert.equal(result.runtimeTruth.beforeServiceMainPid, "1234");
+  assert.equal(result.runtimeTruth.afterServiceMainPid, "5678");
+  assert.equal(result.runtimeTruth.beforeServiceActiveEnterTimestamp, "Thu 2026-06-04 15:00:46 JST");
+  assert.equal(result.runtimeTruth.afterServiceActiveEnterTimestamp, "Thu 2026-06-04 18:23:12 JST");
   assert.deepEqual(fake.calls.filter((call) => call[0] === "systemctl" && call.includes("restart")), [
     ["systemctl", "--user", "restart", "vtdd-dashboard-app-server-bridge-unresolved.service"]
   ]);
+});
+
+test("deploy bridge sync/restart helper does not treat unchanged service state as completion", async () => {
+  const fake = createFakeRunner({ restartChangesService: false });
+  const result = await runDeployBridgeSyncRestart({
+    cwd: "/repo",
+    service: "vtdd-dashboard-app-server-bridge-unresolved.service",
+    ref: "origin/main",
+    runner: fake.runner,
+    now: () => "2026-06-04T06:00:00.000Z"
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, "restart_unverified");
+  assert.equal(result.runtimeTruth.status, "restart_unverified");
+  assert.equal(result.runtimeTruth.serviceRestarted, false);
+  assert.equal(result.runtimeTruth.restartVerified, false);
+  assert.equal(result.runtimeTruth.beforeServiceMainPid, "1234");
+  assert.equal(result.runtimeTruth.afterServiceMainPid, "1234");
+  assert.match(result.runtimeTruth.reason, /did not change MainPID/);
 });
 
 test("deploy bridge sync/restart helper blocks tracked dirty checkout before restart", async () => {

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -39,7 +39,7 @@ import {
   selectPendingVpsPrivilegedMaintenanceExecutions,
   selectPendingVpsRunnerExecutions
 } from "../scripts/run-vps-runner.mjs";
-import { enqueueVpsLocalHelperExecution } from "../scripts/vps-local-helper-queue.mjs";
+import { completeVpsLocalHelperExecution, enqueueVpsLocalHelperExecution } from "../scripts/vps-local-helper-queue.mjs";
 
 function developmentStrategyFixture() {
   return {
@@ -204,6 +204,83 @@ test("VPS runner dry-run selects VPS local helper queue before GitHub Issue comm
   assert.match(result.message, /Dry run selected local privileged maintenance vps-maint-local-dry-run/);
   const pending = await fs.readFile(path.join(queueRoot, "pending", "vps-maint-local-dry-run.json"), "utf8");
   assert.equal(JSON.parse(pending).lifecycle.status, "pending");
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+test("VPS local helper queue state keeps compact restart completion truth", async () => {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-local-state-"));
+  const queueRoot = path.join(tmpRoot, "queue");
+  await enqueueVpsLocalHelperExecution({
+    queueRoot,
+    payload: {
+      executionId: "vps-maint-local-complete",
+      transport: "vps_privileged_maintenance_helper",
+      repository: "sample-org/vtdd-v2",
+      issueNumber: 741,
+      dashboardThreadId: "dashboard-main-unresolved",
+      approvalScopeMatched: true,
+      executionEnvelope: {
+        kind: "vps_privileged_maintenance_helper_execution_envelope",
+        status: "ready_for_vps_helper_execution",
+        repository: "sample-org/vtdd-v2",
+        requestId: "helper-request-local-complete",
+        capabilityId: "dashboard.bridge.unresolved.deploy.sync.restart",
+        mode: "execute",
+        helperInvocation: {
+          executable: "sudo",
+          args: ["-n", "/usr/local/sbin/vtdd-vps-maintenance-helper", "--execute", "--input", "<helper-execution-input-json>"],
+          shell: false,
+          inputFile: "helperExecutionInput"
+        },
+        helperExecutionInput: { mode: "execute", helperRequest: { requestId: "helper-request-local-complete" } },
+        rootExecutionStarted: false,
+        helperExecutionStarted: false
+      }
+    },
+    now: () => "2026-06-07T01:00:00.000Z"
+  });
+  await fs.rename(
+    path.join(queueRoot, "pending", "vps-maint-local-complete.json"),
+    path.join(queueRoot, "running", "vps-maint-local-complete.json")
+  );
+
+  await completeVpsLocalHelperExecution({
+    queueRoot,
+    executionId: "vps-maint-local-complete",
+    status: "completed",
+    result: {
+      rootExecutionStarted: true,
+      helperExecutionStarted: true,
+      runtimeTruth: {
+        status: "synced_and_restarted",
+        serviceRestarted: true,
+        restartVerified: true,
+        syncVerified: true,
+        beforeSha: "before-sha",
+        afterSha: "after-sha",
+        targetRefSha: "after-sha",
+        beforeServiceMainPid: "1234",
+        afterServiceMainPid: "5678",
+        beforeServiceActiveEnterTimestamp: "Thu 2026-06-04 15:00:46 JST",
+        afterServiceActiveEnterTimestamp: "Thu 2026-06-04 18:23:12 JST"
+      },
+      helperResult: {
+        status: "completed",
+        redactedLogSummary: "this must not be copied into state"
+      }
+    },
+    now: () => "2026-06-07T01:02:00.000Z"
+  });
+
+  const state = JSON.parse(await fs.readFile(path.join(queueRoot, "state", "vps-maint-local-complete.json"), "utf8"));
+  assert.equal(state.status, "completed");
+  assert.equal(state.result.runtimeStatus, "synced_and_restarted");
+  assert.equal(state.result.helperStatus, "completed");
+  assert.equal(state.result.serviceRestarted, true);
+  assert.equal(state.result.restartVerified, true);
+  assert.equal(state.result.beforeServiceMainPid, "1234");
+  assert.equal(state.result.afterServiceMainPid, "5678");
+  assert.equal(JSON.stringify(state).includes("redactedLogSummary"), false);
   await fs.rm(tmpRoot, { recursive: true, force: true });
 });
 

--- a/test/vps-runner-script.test.js
+++ b/test/vps-runner-script.test.js
@@ -882,36 +882,43 @@ test("VPS runner event reads dashboard runtime URL from default vault manifest w
 });
 
 test("VPS runner event records missing runtime dashboard delivery configuration", async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-missing-runtime-"));
   const calls = [];
-  await postVpsRunnerEvent({
-    githubFetch: async (url, init = {}) => {
-      calls.push({ url, init });
-      return { id: 45004 };
-    },
-    payload: {
-      executionId: "exec-dashboard-missing-runtime",
-      repository: "marushu/vtdd-v2-p",
-      issueNumber: 450,
-      handoff: {
-        dashboardThreadId: "dashboard-main-marushu-vtdd-v2-p"
+  try {
+    await postVpsRunnerEvent({
+      githubFetch: async (url, init = {}) => {
+        calls.push({ url, init });
+        return { id: 45004 };
+      },
+      payload: {
+        executionId: "exec-dashboard-missing-runtime",
+        repository: "marushu/vtdd-v2-p",
+        issueNumber: 450,
+        handoff: {
+          dashboardThreadId: "dashboard-main-marushu-vtdd-v2-p"
+        }
+      },
+      event: {
+        status: "completed",
+        lastEvent: "branch_pushed",
+        currentStep: "branch_pushed",
+        message: "完了"
+      },
+      env: {
+        VTDD_VPS_RUNNER_CREDENTIALS_MANIFEST: path.join(tempDir, "missing-manifest.json")
       }
-    },
-    event: {
-      status: "completed",
-      lastEvent: "branch_pushed",
-      currentStep: "branch_pushed",
-      message: "完了"
-    },
-    env: {}
-  });
+    });
 
-  const parsed = parseVpsRunnerEventComment(calls[0].init.body.body);
-  assert.equal(parsed.ok, true);
-  assert.equal(parsed.event.dashboardDelivery.status, "skipped");
-  assert.equal(
-    parsed.event.dashboardDelivery.reason,
-    "VTDD_RUNTIME_URL or VTDD_GATEWAY_BEARER_TOKEN is missing"
-  );
+    const parsed = parseVpsRunnerEventComment(calls[0].init.body.body);
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.event.dashboardDelivery.status, "skipped");
+    assert.equal(
+      parsed.event.dashboardDelivery.reason,
+      "VTDD_RUNTIME_URL or VTDD_GATEWAY_BEARER_TOKEN is missing"
+    );
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("VPS runner milestone event mentions queue comment author", () => {
@@ -2029,15 +2036,22 @@ test("VPS runner actor identity incident starts with Japanese owner notification
 });
 
 test("VPS runner role App token resolution fails closed when role credentials are missing", async () => {
-  const result = await resolveRoleGitHubAppInstallationToken({
-    role: "codex_fallback_reviewer",
-    env: {},
-    apiBaseUrl: "https://api.github.com"
-  });
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "vtdd-vps-missing-role-vault-"));
+  try {
+    const result = await resolveRoleGitHubAppInstallationToken({
+      role: "codex_fallback_reviewer",
+      env: {
+        VTDD_VPS_RUNNER_CREDENTIALS_MANIFEST: path.join(tempDir, "missing-manifest.json")
+      },
+      apiBaseUrl: "https://api.github.com"
+    });
 
-  assert.equal(result.ok, false);
-  assert.equal(result.reason.includes("VTDD Codex Fallback Reviewer"), true);
-  assert.equal(result.reason.includes("missing app id, private key, installation id"), true);
+    assert.equal(result.ok, false);
+    assert.equal(result.reason.includes("VTDD Codex Fallback Reviewer"), true);
+    assert.equal(result.reason.includes("missing app id, private key, installation id"), true);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("VPS runner role App token resolution can read role credentials from vault manifest", async () => {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #741 の deploy 後 bridge restart completion truth を固める。runner wake や script 起動を restart 完了と呼ばず、VPS local helper queue state と helper runtimeTruth で synced/restarted/failed を区別できるようにする。

## Satisfied Success Criteria

- deploy 後 bridge sync/restart helper が origin/main 同期後の git HEAD と systemd service before/after state を runtimeTruth に含める。VPS local helper queue の state summary が compact な restart completion truth を返す。Dashboard app-server bridge の enqueue response が runner wake は launch truth であり completion truth は helper queue state を見る必要があると明示する。

## Unsatisfied Success Criteria

- production VPS 上の deploy -> passkey approval -> local helper runner pickup -> bridge restart completed/failed notification の iPhone Butler E2E はこの PR では未実施。deploy 自体、VPS service restart 実行、credential/permission mutation はこの PR では行わない。

## Non-goal violations

deploy 実行、VPS service restart 実行、GitHub Issue comment helper queue の復活、Action Schema 変更、voice mode / 差し込み UX 変更は non-goal。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-741-restart-completion-truth.md
- 完了体験: オーナーが Dashboard Butler から deploy 後 bridge restart を承認したあと、Butler が script 起動結果ではなく、VPS local helper queue の completed/failed state と runtimeTruth を読んで restart 完了または未確認理由を返せる状態にする。
- VTDD 全体で進める部分: Issue #741 の deploy 後 app-server bridge restart 経路で、passkey operator から VPS local helper queue へ渡った後の completion truth を短く安定させる。
- 設計: owner-facing surface は Dashboard Butler。scope は helper script、VPS local helper queue summary、app-server bridge enqueue response、対応テストに限定する。authority boundary は未変更で、deploy/restart 実行は passkey 承認後の runtime 側に残す。
- 仮説: 仮説: これまでの混乱原因は runner wake / script 起動 / systemctl restart exit code 0 が completion truth と混ざったこと。service before/after の MainPID または ActiveEnterTimestamp 変化を検証しないと、長期起動しっぱなしの bridge が本当に再起動したか説明できない。
- 検証計画: node --test で helper script の success/failure、Dashboard bridge enqueue の pending completion truth、VPS local helper queue の compact summary を検証する。git diff --check と npm run check:generated-worker で生成物 drift も確認する。production VPS の deploy/restart E2E は merge/deploy 後の mapped E2E として残す。
- 改修見積もり: docs/development-strategy/issue-741-restart-completion-truth.md に作戦図を追加。scripts/sync-dashboard-app-server-bridge-after-deploy.mjs の runDeployBridgeSyncRestart と service state parsing を変更。scripts/vps-local-helper-queue.mjs の summarizeState/result を変更。scripts/run-dashboard-app-server-bridge.mjs の enqueue response を変更。test/*.js に対応検証を追加。
- 既に通っている経路: PR #823-#828 で passkey operator -> app-server bridge -> VPS local helper queue enqueue -> runner wake の launch path は整っている。今回の PR は launch 後の completion state を queue/state/log から読みやすくする。
- 未確認の境界: production VPS で実際に systemd が MainPID を変えるか、oneshot/exec wrapper で ActiveEnterTimestamp のみ変わるかは live E2E で確認する必要がある。通知 delivery の最終 owner-facing 表示も deploy 後検証が必要。
- 穴が出そうな箇所: service restart が同一 PID に見える環境、ActiveEnterTimestamp の locale 差、helper queue completed state を Butler がまだ読まずに enqueue response だけ表示する経路、通知未達時の recovery 表示が穴になり得る。
- PR 前に確認すること: AGENTS.md、docs/butler/thread-independent-startup-contract.md、docs/butler/execution-queue-contract.md、docs/mvp/active-issue-execution-queue.md、Issue #741 関連 PR truth、既存 helper scripts/tests を確認した。PR 前に node --test、git diff --check、generated-worker check を実施する。
- 実装候補と捨てた案: 捨てた案: GitHub Issue comment helper queue を復活させる案、enqueue response を完了扱いにする案、Worker から root/helper restart を直接実行する案、systemctl restart exit code 0 のみで completion とする案。いずれも Issue #741 の現行 root path と authority boundary を崩す。
- merge 後に通す E2E: Issue #741 production VPS E2E: deploy 後に passkey operator から bridge restart を実行し、VPS local helper queue state が running から completed/failed に遷移し、runtimeTruth に before/after git SHA と before/after service state が出ることを Dashboard Butler で確認する。
- 次の PR を増やさない理由: この PR は予測できる completion truth の穴を同じ #741 scope 内で閉じる。production notification delivery や iPhone E2E は既存 #741 の merge/deploy 後 evidence として残し、新しい PR を増やして active Issues を縮小しない。
- 停止条件: helper queue が completion state を保存できない、service before/after state が取得不能、Dashboard Butler が helper queue state を読めないことが判明した場合は、completion claim を止めて #741 の未接続 blocker として報告する。

## Dry-run Impact Report

- Target Issue: Issue #741
- Implementing Success Criteria: deploy 後 bridge restart について、launch truth と completion truth を分離し、helper runtimeTruth が syncVerified/restartVerified/serviceRestarted/before-after state を返すこと。
- Explicit Non-goals: deploy実行、VPS service restart実行、credential/permission mutation、GitHub Issue comment helper queue 復活、voice/diff insertion UX 変更。
- Expected touched files/routes/workflows: docs/development-strategy/issue-741-restart-completion-truth.md、scripts/sync-dashboard-app-server-bridge-after-deploy.mjs、scripts/vps-local-helper-queue.mjs、scripts/run-dashboard-app-server-bridge.mjs、test/sync-dashboard-app-server-bridge-after-deploy.test.js、test/vps-runner-script.test.js、test/dashboard-app-server-bridge.test.js。
- Affected Issues: Issue #741 を進める。Issue #816/#814/#811/#637/#450 は active のまま縮小しない。
- Affected PRs: 直近 merged PR #823-#828 の runtime path に追従する。新規 PR として作成し、merged PR branch には push しない。
- Affected workflows: GitHub Actions は通常 test/check のみ。deploy workflow、reviewer、credential workflow は変更しない。
- Affected runtime/operator surfaces: Dashboard Butler、app-server bridge、VPS local helper queue、deploy bridge restart helper script の truth 表示に影響する。Worker から root/helper restart は実行しない。
- What may break if we patch narrowly: enqueue/wakeup だけを完了扱いにすると、再起動未完了でも owner-facing に成功と見える。service state 検証だけを helper 内に閉じると Butler が completion state を読めない。
- Unknowns to investigate before coding: production VPS の systemd service state 変化、通知 delivery 表示、Dashboard Butler の final completion readback は merge/deploy 後 E2E で確認する。
- Validation needed: unit/integration: node --test 対象ファイル。runtime truth: helper queue state の completed/failed summary。E2E: merge/deploy 後 production VPS passkey restart flow。
- Stop condition: Issue #741 外の deploy/restart 実行、権限変更、GitHub Issue comment queue 復活、voice/diff insertion 変更が必要になったら停止する。

## Execution Queue Delta

- Queue position before: Issue #741 は Root/Now 相当の deploy 後 bridge restart recovery blocker。#816/#814/#811 は Next/Queue に残る。
- Preemption decision: ROOT: deploy 後 app-server bridge restart completion truth は Butler 経由開発の recovery blocker なので #741 の scoped progress として扱う。
- Queue delta: Issue #741 の Now/root blocker を completion truth 補強で進める。PR #823-#828 の launch path は維持し、Queue/Next の active Issues は動かさない。
- Why this PR is next: deploy 後に bridge restart 通知が来ないという owner-facing confusion があり、次の voice/diff insertion 開発より先に recovery truth を安定させる必要がある。
- Active Issues not downscoped: Active Issues は縮小しない。#816/#814/#811/#637/#450 などは未完了として remain active。

## File / Line Hypotheses

- file: scripts/sync-dashboard-app-server-bridge-after-deploy.mjs; hypothesis: runDeployBridgeSyncRestart が restart exit code と after git state だけで成功扱いに寄りやすい; risk if changed narrowly: service 未再起動でも synced_and_restarted と見える; validation: sync helper tests。
- file: scripts/vps-local-helper-queue.mjs; hypothesis: completed record の result summary が owner-facing restart truth として不足する; risk if changed narrowly: raw log 依存または長文化する; validation: queue state summary test。
- file: scripts/run-dashboard-app-server-bridge.mjs; hypothesis: enqueue response が completion と誤読される; risk if changed narrowly: runner wake を完了通知と誤解する; validation: dashboard bridge test。

## Hypothesis Retrospective

- expected: service before/after state を runtimeTruth に持たせれば restart 完了/未確認を分離できる。
- actual: helper script は restartVerified を返し、unchanged service state を restart_unverified として fail closed にした。
- mismatch: production VPS の final notification E2E は未実施なので completion status は incomplete。
- lesson: launch truth と completion truth を同じ文言にしない。
- should become RAG candidate: Issue #741 の deploy/restart recovery rule として候補。

## Verification Evidence

- Unit: node --test test/sync-dashboard-app-server-bridge-after-deploy.test.js: PASS。node --test test/vps-runner-script.test.js: PASS 81/81。node --test test/active-issue-execution-queue.test.js: PASS。
- Integration: node --test test/sync-dashboard-app-server-bridge-after-deploy.test.js test/dashboard-app-server-bridge.test.js: PASS 87/87。node --test test/dashboard-app-server-bridge.test.js --test-name-pattern "local helper|wakeup|deploy restart|bridge sync|restart": PASS。npm run check:generated-worker: PASS。git diff --check: PASS。
- E2E: Not run. production VPS deploy/passkey/restart notification E2E は merge/deploy 後に必要。
- Manual: Gemini request_changes 対応として、実 VPS の runtime/vault env を拾っていた既存 2 tests を一時 manifest path で隔離し、test/vps-runner-script.test.js full pass を確認した。
- Evidence path/link: docs/development-strategy/issue-741-restart-completion-truth.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler
- Fallback surface: Custom GPT は fallback surface としてのみ扱う。主経路ではない。
- Owner goal: deploy 後 bridge restart の承認後に、起動しただけではなく restart 完了/未確認/失敗の runtime truth を Butler で読めること。
- Butler entrypoint: Dashboard Butler の通常チャットと passkey operator continuation。新しい raw API 入力は要求しない。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャット entrypoint から deploy 後 bridge restart の状況確認に到達する経路を前提にし、この PR は completion truth の接続情報を補強する。
- Action Schema exposure: Custom GPT Action Schema は未変更。主経路とは扱わない。
- Runtime path: Dashboard Butler -> app-server bridge -> passkey approval -> VPS local helper queue enqueue/wake -> local runner -> sync-dashboard-app-server-bridge-after-deploy helper -> queue completed/failed state。
- Runner/runtime truth: enqueue/wake は pending_vps_runner_completion。helper completion は runtimeTruth.status、syncVerified、restartVerified、serviceRestarted、before/after git SHA、before/after service MainPID/ActiveEnterTimestamp で報告する。
- Authority boundary: 未変更。deploy/restart 実行は passkey 承認が必要。この PR はコードとテストのみで、高リスク外部効果は実行しない。
- E2E evidence: 未実施。merge/deploy 後に iPhone Dashboard Butler から passkey restart flow を通し、helper queue state と通知/readback を確認する必要がある。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。この PR 作成時点では deploy しない。merge 後に owner/passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate、Authority Boundary、Drift Stop Protocol、開発前作戦図 Gate、Execution Queue Contract、Issue #741 scope。

## Out-of-scope but NOT implemented

- production deploy/restart 実行。GitHub Issue comment helper queue 復活。voice mode と差し込み UX 修正。Issue closure。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #741
- Execution ID: mac-codex-issue-741-restart-completion-truth-2026-06-08
- Goal: Issue #741 deploy 後 bridge restart completion truth を短く安定させる
