### PR TITLE
Issue #741 quiet restart launch truth

### DIFF
--- a/docs/development-strategy/issue-741-quiet-restart-launch-truth.md
+++ b/docs/development-strategy/issue-741-quiet-restart-launch-truth.md
@@ -41,6 +41,8 @@ production PWA で transient progress がどの程度見えるべきかは未確
 
 launch truth を完全に消すと debug が難しくなる。runtime response / deployBridgeFollowup object / logs には残し、通常 message だけを抑制する必要がある。
 
+owner screenshot では通常 chat message だけでなく、投入済み follow-up が `差し込み済み` chip として composer に残っていた。送信済み item は owner が次に操作できる queue ではないため、composer 上には未送信 queue だけを残す。これは Issue #816 の queue UX blocker だが、今回の restart launch truth ノイズが composer に居座る直接原因でもある。
+
 ## PR 前に確認すること
 
 Issue #741 の authority boundary、PR #829 の completion truth、test/worker の deploy bridge restart expectations、generated worker drift を確認する。
@@ -56,6 +58,8 @@ Issue #741 の authority boundary、PR #829 の completion truth、test/worker �
 ## merge 後に通す E2E
 
 production deploy 後、passkey approved bridge restart で通常 chat に `起動結果` / `restart 完了結果ではありません` / `before/after truth が戻るまで` の中間 message が積まれず、最終 completion/failure truth だけが owner-facing に残ることを確認する。
+
+同じ production PWA で、差し込みを送信したあと composer 上に `差し込み済み` chip が残らず、未送信 queue item だけが `キュー待ち` として表示されることを確認する。
 
 ## 次の PR を増やさない理由
 

--- a/docs/development-strategy/issue-741-quiet-restart-launch-truth.md
+++ b/docs/development-strategy/issue-741-quiet-restart-launch-truth.md
@@ -1,0 +1,66 @@
+# Issue #741 quiet restart launch truth 作戦図
+
+## 完了体験
+
+Owner が deploy 後 bridge restart を承認したあと、Dashboard Butler の通常チャットには deploy 完了や最終的な failure / completion truth だけが残る。`bridge_control_sent`、`launch_started`、`runner wake` のような中間 launch truth は通常 message として積み上がらず、必要な場合だけ transient progress / runtime truth / debug evidence として扱われる。
+
+## VTDD 全体で進める部分
+
+Issue #741 の deploy 後 bridge restart 経路で、PR #829 が固めた before/after completion truth を邪魔しない表示境界を整える。restart の安全境界は維持するが、owner-facing normal chat を低情報な lifecycle message で汚さない。
+
+## 設計
+
+`bridge_control_sent` と `launch_started` は terminal truth ではない。通常チャットに残すと owner は「何か完了したのか」「まだ待つべきなのか」を毎回読まされる。成功系の launch truth は persisted chat message にしない。失敗、blocked、duplicate は recovery 判断に必要なので message として残す。deploy 完了 message の次 action も、bridge restart launch を逐一説明せず production E2E / runtime truth 確認へ寄せる。
+
+## 仮説
+
+原因は `buildDeployBridgeFollowupChatMessage()` の `bridge_control_sent` message と、`acceptDeployBridgeSyncRestartResult()` の `launch_started` result message が、どちらも `DashboardChatStore.appendMany()` に渡っていること。これにより通常チャットに中間状態が二重に残る。
+
+## 検証計画
+
+- Unit: deploy event success は deploy 完了 message だけを append し、bridge follow-up launch message を append しない。
+- Unit: `deploy_bridge_sync_restart_result` の `launch_started` は transient / persisted chat message を追加しない。
+- Unit: `launch_failed` は引き続き persisted failed message を追加し、retry guard を release する。
+- Local: `npm run build:worker`、`npm run verify:worker`、関連 `node --test test/worker.test.js --test-name-pattern ...`。
+
+## 改修見積もり
+
+- `src/worker/runtime.js`: `bridge_control_sent` の `message` を null にし、deploy completion text から中間 launch 説明を外す。`normalizeDeployBridgeSyncRestartResult()` / accept path で `launch_started` を append しない。risk は owner が launch 状態を全く見えなくなることだが、これは transient/debug に限定するのが今回の目的。
+- `test/worker.test.js`: deploy event append 件数、launch_started 非保存、launch_failed 保存の期待値を更新する。
+- `worker.js`: Worker bundle を再生成する。
+
+## 既に通っている経路
+
+PR #829 で restart completion truth は helper queue / runtimeTruth に残る。deploy event、app-server bridge control、VPS local helper queue、runner wake の主経路は存在する。
+
+## 未確認の境界
+
+production PWA で transient progress がどの程度見えるべきかは未確認。今回の PR は「通常チャットに残さない」を目的にし、最終 completion readback の E2E は merge/deploy 後に確認する。
+
+## 穴が出そうな箇所
+
+launch truth を完全に消すと debug が難しくなる。runtime response / deployBridgeFollowup object / logs には残し、通常 message だけを抑制する必要がある。
+
+## PR 前に確認すること
+
+Issue #741 の authority boundary、PR #829 の completion truth、test/worker の deploy bridge restart expectations、generated worker drift を確認する。
+
+## 実装候補と捨てた案
+
+採用: success launch message を null にして persisted chat append を止める。
+
+捨てた案: 文言だけ短くする。owner の不満は「出ること」なので、短文化では解決しない。
+
+捨てた案: restart truth そのものを消す。completion/failure/recovery evidence が失われるため不可。
+
+## merge 後に通す E2E
+
+production deploy 後、passkey approved bridge restart で通常 chat に `起動結果` / `restart 完了結果ではありません` / `before/after truth が戻るまで` の中間 message が積まれず、最終 completion/failure truth だけが owner-facing に残ることを確認する。
+
+## 次の PR を増やさない理由
+
+この UX 漏れは PR #829 の completion truth を owner-facing にする前提を壊す。message 抑制と tests は同じ failure mode なので同じ PR で閉じる。
+
+## 停止条件
+
+通常 message を止めるために restart completion truth、failure message、retry guard、authority boundary を壊す必要が出た場合は停止する。

--- a/docs/development-strategy/issue-816-followup-queue-media.md
+++ b/docs/development-strategy/issue-816-followup-queue-media.md
@@ -82,3 +82,10 @@ Worker media validation が差し込み payload を拒否する、upload 済み 
 - 判断: production E2E 以前の UX/state blocker。#817 の範囲内で、draft panel に `差し込む` / `キューに追加` / `キャンセル` を出し、`差し込む` は即 `interruption: true` で送る。
 - reload recovery: queued follow-up は `sessionStorage` に thread 単位で保存し、reload/reconnect 後も queue chip を復元する。未 upload の local file はブラウザ仕様上復元できないため、既存 draft text 復元と「添付は再選択」表示に留める。
 - validation: source guard と local Playwright E2E に、初期 draft panel の `差し込む` button、直接差し込み payload、queued follow-up reload persistence を追加する。
+
+## 2026-06-08 owner blocker: 投入済みカードを composer に残さない
+
+- 観測: production PWA で投入済み follow-up が `差し込み済み` chip として composer 上に残り、bridge restart launch truth のような内部運用文言まで入力欄付近に居座っている。owner は「投入しているのだから消せ」と判断した。
+- 判断: #816 の queue UX 欠陥。composer 上に残すべきものは owner が次に操作できる未送信 queue だけであり、送信済み follow-up は thread message / bridge input の truth に移った時点で composer queue から消す。
+- 設計: `followupQueue` の保存・描画対象を `status === "queued"` に限定する。送信成功した item は `sent` 表示へ遷移させず queue から削除する。cancel も sent item を温存しない。
+- 検証計画: source guard で `差し込み済み` label が runtime HTML に残らないこと、`sendFollowupQueueItem()` が送信成功後に queue から remove すること、persist 対象が queued のみであることを確認する。既存の添付保持と deploy/restart launch 静音化 test も再実行する。

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -17972,14 +17972,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       function renderFollowupQueue() {
         if (!followupQueueList) return;
+        const queuedItems = followupQueue.filter((item) => item && item.status === "queued");
         followupQueueList.replaceChildren();
-        followupQueueList.hidden = followupQueue.length === 0;
-        for (const item of followupQueue) {
+        followupQueueList.hidden = queuedItems.length === 0;
+        for (const item of queuedItems) {
           const mediaReferences = Array.isArray(item.mediaReferences) ? item.mediaReferences : [];
           const chip = document.createElement("div");
           chip.className = "followup-chip";
           const label = document.createElement("small");
-          label.textContent = item.status === "sent" ? "差し込み済み" : "キュー待ち";
+          label.textContent = "キュー待ち";
           const text = document.createElement("span");
           text.textContent = item.text;
           chip.appendChild(label);
@@ -17989,29 +17990,27 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             media.textContent = "添付 " + mediaReferences.length + "件";
             chip.appendChild(media);
           }
-          if (item.status === "queued") {
-            const actions = document.createElement("div");
-            actions.className = "followup-actions";
-            const guideButton = document.createElement("button");
-            guideButton.type = "button";
-            guideButton.dataset.followupAction = "guide";
-            guideButton.dataset.followupId = item.id;
-            guideButton.textContent = "誘導する";
-            const editButton = document.createElement("button");
-            editButton.type = "button";
-            editButton.dataset.followupAction = "edit";
-            editButton.dataset.followupId = item.id;
-            editButton.textContent = "編集する";
-            const cancelButton = document.createElement("button");
-            cancelButton.type = "button";
-            cancelButton.dataset.followupAction = "cancel";
-            cancelButton.dataset.followupId = item.id;
-            cancelButton.textContent = "キャンセル";
-            actions.appendChild(guideButton);
-            actions.appendChild(editButton);
-            actions.appendChild(cancelButton);
-            chip.appendChild(actions);
-          }
+          const actions = document.createElement("div");
+          actions.className = "followup-actions";
+          const guideButton = document.createElement("button");
+          guideButton.type = "button";
+          guideButton.dataset.followupAction = "guide";
+          guideButton.dataset.followupId = item.id;
+          guideButton.textContent = "誘導する";
+          const editButton = document.createElement("button");
+          editButton.type = "button";
+          editButton.dataset.followupAction = "edit";
+          editButton.dataset.followupId = item.id;
+          editButton.textContent = "編集する";
+          const cancelButton = document.createElement("button");
+          cancelButton.type = "button";
+          cancelButton.dataset.followupAction = "cancel";
+          cancelButton.dataset.followupId = item.id;
+          cancelButton.textContent = "キャンセル";
+          actions.appendChild(guideButton);
+          actions.appendChild(editButton);
+          actions.appendChild(cancelButton);
+          chip.appendChild(actions);
           followupQueueList.appendChild(chip);
         }
         updateComposerReserve();
@@ -18039,7 +18038,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             mediaReferences: Array.isArray(item.mediaReferences) ? item.mediaReferences : [],
             interruption: true
           }));
-          item.status = "sent";
+          followupQueue = followupQueue.filter((queuedItem) => queuedItem.id !== item.id);
+          restoredFollowupQueueNeedsOwnerAction = false;
           persistFollowupQueue();
           renderFollowupQueue();
           return true;
@@ -18058,7 +18058,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function cancelFollowupQueueItem(itemId) {
         const before = followupQueue.length;
         restoredFollowupQueueNeedsOwnerAction = false;
-        followupQueue = followupQueue.filter((item) => item.id !== itemId || item.status === "sent");
+        followupQueue = followupQueue.filter((item) => item.id !== itemId);
         if (followupQueue.length !== before) {
           persistFollowupQueue();
           renderFollowupQueue();

--- a/src/worker/runtime.js
+++ b/src/worker/runtime.js
@@ -788,17 +788,21 @@ export class DashboardChatRoom {
     if (normalized.status === "launch_failed") {
       await this.releaseDeployBridgeControlClaim(this.deployBridgeControlIdempotencyKey(normalized));
     }
-    await this.broadcastTransientStatus({
-      threadId: normalized.threadId,
-      status: normalized.transientStatus,
-      text: normalized.transientText,
-      snapshot: normalized.status === "launch_started",
-      snapshotSource: "deploy_bridge_sync_restart_result"
-    });
+    if (normalized.transientStatus) {
+      await this.broadcastTransientStatus({
+        threadId: normalized.threadId,
+        status: normalized.transientStatus,
+        text: normalized.transientText,
+        snapshot: normalized.status === "launch_started",
+        snapshotSource: "deploy_bridge_sync_restart_result"
+      });
+    }
     const store = resolveDashboardChatStore(this.env);
-    const messages = store
-      ? await store.appendMany(normalized.threadId, [normalized.message])
-      : [normalized.message].filter(Boolean);
+    const messages = normalized.message
+      ? store
+        ? await store.appendMany(normalized.threadId, [normalized.message])
+        : [normalized.message]
+      : [];
     await this.broadcastThread({ threadId: normalized.threadId, messages });
   }
 
@@ -5592,25 +5596,7 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
       rootExecutionStarted: false,
       helperExecutionStarted: true
     },
-    message: normalizeDashboardChatMessage(
-      {
-        threadId,
-        messageId,
-        role: "system",
-        repository,
-        relatedIssue,
-        status: "sent",
-        text: buildDeployBridgeFollowupControlMessageText({
-          record,
-          repository,
-          relatedIssue,
-          executionId,
-          control
-        }),
-        createdAt: record.updatedAt || record.createdAt
-      },
-      { threadId }
-    )
+    message: null
   };
 }
 
@@ -5759,7 +5745,8 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
   const requestId = normalizeDashboardEventText(input.requestId || input.request_id);
   const executionId = normalizeDashboardEventText(input.executionId || input.execution_id);
   const createdAt = normalizeIsoTimestamp(input.completedAt || input.completed_at || input.createdAt || input.created_at) || new Date().toISOString();
-  const transientStatus = status === "launch_failed" || status === "blocked" ? "failed" : "thinking";
+  const quietLaunch = status === "launch_started";
+  const transientStatus = quietLaunch ? "" : status === "launch_failed" || status === "blocked" ? "failed" : "thinking";
   const transientText = buildDeployBridgeSyncRestartResultTransientText({ status });
   const text = buildDeployBridgeSyncRestartResultMessageText({
     status,
@@ -5784,19 +5771,21 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
     executionId,
     transientStatus,
     transientText,
-    message: normalizeDashboardChatMessage(
-      {
-        threadId,
-        role: "system",
-        repository,
-        relatedIssue,
-        status: status === "launch_failed" || status === "blocked" ? "failed" : "sent",
-        text,
-        messageId: `deploy-bridge-sync-restart-result:${deployRunId || requestId || createDashboardRequestId("result")}:${status}`,
-        createdAt
-      },
-      { threadId }
-    )
+    message: quietLaunch
+      ? null
+      : normalizeDashboardChatMessage(
+          {
+            threadId,
+            role: "system",
+            repository,
+            relatedIssue,
+            status: status === "launch_failed" || status === "blocked" ? "failed" : "sent",
+            text,
+            messageId: `deploy-bridge-sync-restart-result:${deployRunId || requestId || createDashboardRequestId("result")}:${status}`,
+            createdAt
+          },
+          { threadId }
+        )
   };
 }
 
@@ -15311,7 +15300,6 @@ function buildGitHubActionsDashboardChatMessageText(event) {
   }
   lines.push("", "次:");
   if (isDeploy && conclusion === "success") {
-    lines.push("- deploy 後 bridge sync/restart を接続中 app-server bridge へ一回限りで送ります。");
     lines.push("- production E2E / runtime truth を確認します。");
   } else if (conclusion === "failure" || conclusion === "cancelled" || conclusion === "timed_out") {
     lines.push("- deploy / Actions の失敗原因を確認し、blocker と次 action を出します。");

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -5179,6 +5179,42 @@ test("DashboardChatRoom records deploy bridge restart result and releases failed
   assert.equal(bridgeSocket.sent.length, 2);
 });
 
+test("DashboardChatRoom does not persist deploy bridge restart launch-only result", async () => {
+  const dashboardSocket = createMockSocket("dashboard", "dashboard-main-marushu-vtdd-v2-p");
+  const bridgeSocket = createMockSocket("app_server_bridge", "dashboard-main-marushu-vtdd-v2-p");
+  const store = createInMemoryDashboardChatStore();
+  const room = new DashboardChatRoom(
+    {
+      storage: createMockDurableObjectStorage(),
+      getWebSockets() {
+        return [dashboardSocket, bridgeSocket];
+      }
+    },
+    { DASHBOARD_CHAT_STORE: store }
+  );
+
+  await room.webSocketMessage(
+    bridgeSocket,
+    JSON.stringify({
+      type: "deploy_bridge_sync_restart_result",
+      threadId: "dashboard-main-marushu-vtdd-v2-p",
+      requestId: "deploy-bridge-restart:test",
+      executionId: "deploy-bridge-followup-123",
+      deployRunId: "123",
+      repository: "marushu/vtdd-v2-p",
+      relatedIssue: 741,
+      status: "launch_started",
+      completedAt: "2026-06-07T00:00:01.000Z"
+    })
+  );
+
+  const messages = await store.listThread("dashboard-main-marushu-vtdd-v2-p", { limit: 10 });
+  assert.equal(messages.length, 0);
+  const sentPayloads = dashboardSocket.sent.map((message) => JSON.parse(message));
+  assert.equal(sentPayloads.some((message) => message.type === "transient_status"), false);
+  assert.equal(JSON.stringify(sentPayloads).includes("起動結果であり"), false);
+});
+
 test("DashboardChatRoom attaches execution queue preflight to repository app-server turns", async () => {
   const provider = createInMemoryMemoryProvider();
   const store = createInMemoryDashboardChatStore();
@@ -7826,7 +7862,7 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(eventBody.chatAppendStatus, "appended");
   assert.equal(eventBody.chatAppendError, null);
   assert.equal(eventBody.chatAppendReason, null);
-  assert.equal(eventBody.messages.length, 2);
+  assert.equal(eventBody.messages.length, 1);
   assert.equal(eventBody.messages[0].messageId, "dashboard-event:github-actions:marushu/vtdd-v2-p:deploy-production:26133044458");
   assert.equal(eventBody.messages[0].role, "system");
   assert.equal(eventBody.messages[0].repository, "marushu/vtdd-v2-p");
@@ -7834,18 +7870,11 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   assert.equal(eventBody.messages[0].status, "replied");
   assert.equal(eventBody.messages[0].text.includes("デプロイ完了イベントを受信しました。"), true);
   assert.equal(eventBody.messages[0].text.includes("- PR: PR #552"), true);
-  assert.equal(eventBody.messages[0].text.includes("deploy 後 bridge sync/restart を接続中 app-server bridge へ一回限りで送ります。"), true);
+  assert.equal(eventBody.messages[0].text.includes("deploy 後 bridge sync/restart を接続中 app-server bridge へ一回限りで送ります。"), false);
   assert.equal(eventBody.messages[0].text.includes("- production E2E / runtime truth を確認します。"), true);
   assert.equal(eventBody.messages[0].text.includes("merge / deploy / credential / permission"), true);
-  assert.equal(eventBody.messages[1].messageId, "dashboard-event:github-actions:marushu/vtdd-v2-p:deploy-production:26133044458:deploy-bridge-followup");
-  assert.equal(eventBody.messages[1].role, "system");
-  assert.equal(eventBody.messages[1].status, "sent");
-  assert.equal(eventBody.messages[1].relatedIssue, 741);
-  assert.equal(eventBody.messages[1].text.includes("deploy 後 bridge sync/restart を接続中 app-server bridge へ一回限りで送りました。"), true);
-  assert.equal(eventBody.messages[1].text.includes("vtdd-dashboard-app-server-bridge-unresolved.service"), true);
-  assert.equal(eventBody.messages[1].text.includes("追加 passkey は不要です。"), true);
-  assert.equal(eventBody.messages[1].text.includes("GitHub Issue comment queue は作成しません。"), true);
-  assert.equal(eventBody.messages[1].text.includes("status=bridge_control_sent, queueCommentPosted=false"), true);
+  assert.equal(JSON.stringify(eventBody.messages).includes("bridge 再接続または VPS journal"), false);
+  assert.equal(JSON.stringify(eventBody.messages).includes("status=bridge_control_sent"), false);
   assert.equal(eventBody.deployBridgeFollowup.status, "bridge_control_sent");
   assert.equal(eventBody.deployBridgeFollowup.proposalCreated, false);
   assert.equal(eventBody.deployBridgeFollowup.queueCreated, false);
@@ -7906,13 +7935,13 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
   );
   assert.equal(chatResponse.status, 200);
   const chatBody = await chatResponse.json();
-  assert.equal(chatBody.messages.length, 2);
+  assert.equal(chatBody.messages.length, 1);
   assert.equal(chatBody.messages[0].role, "system");
   assert.equal(chatBody.messages[0].text.includes("デプロイ完了イベントを受信しました。"), true);
   assert.equal(chatBody.messages[0].text.includes("- PR: PR #552"), true);
   assert.equal(chatBody.messages[0].text.includes("bare #552"), false);
-  assert.equal(chatBody.messages[1].text.includes("approval URL:"), false);
-  assert.equal(chatBody.messages[1].text.includes("追加 passkey は不要です。"), true);
+  assert.equal(JSON.stringify(chatBody.messages).includes("approval URL:"), false);
+  assert.equal(JSON.stringify(chatBody.messages).includes("追加 passkey は不要です。"), false);
 
   const duplicateResponse = await worker.fetch(
     new Request("https://example.com/v2/events/github-actions", {
@@ -7958,7 +7987,7 @@ test("worker ingests GitHub Actions deploy completion event and shows it on dash
     { ...dashboardAccessEnv, DASHBOARD_CHAT_STORE: chatStore }
   );
   const duplicateChatBody = await duplicateChat.json();
-  assert.equal(duplicateChatBody.messages.length, 2);
+  assert.equal(duplicateChatBody.messages.length, 1);
   assert.equal(duplicateChatBody.messages[0].messageId, "dashboard-event:github-actions:marushu/vtdd-v2-p:deploy-production:26133044458");
   assert.equal(duplicateBody.deployBridgeFollowup.status, "duplicate_event_skipped");
   const approvalRecordsAfterDuplicate = await provider.retrieve({ type: MemoryRecordType.APPROVAL_LOG, limit: 20 });

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1385,6 +1385,9 @@ test("worker serves v2 dashboard for allowed owner identity without exposing sec
   assert.equal(body.includes('guideButton.textContent = "誘導する"'), true);
   assert.equal(body.includes('editButton.textContent = "編集する"'), true);
   assert.equal(body.includes('cancelButton.textContent = "キャンセル"'), true);
+  assert.equal(body.includes("差し込み済み"), false);
+  assert.equal(body.includes('label.textContent = "キュー待ち"'), true);
+  assert.equal(body.includes("followupQueue = followupQueue.filter((queuedItem) => queuedItem.id !== item.id)"), true);
   assert.equal(body.includes('function flushFollowupQueueItem(itemId)'), true);
   assert.equal(body.includes('function editFollowupQueueItem(itemId)'), true);
   assert.equal(body.includes('現在の実行が終わるか、キューの誘導するを押した時に送ります'), true);

--- a/worker.js
+++ b/worker.js
@@ -58640,15 +58640,17 @@ var DashboardChatRoom = class {
     if (normalized.status === "launch_failed") {
       await this.releaseDeployBridgeControlClaim(this.deployBridgeControlIdempotencyKey(normalized));
     }
-    await this.broadcastTransientStatus({
-      threadId: normalized.threadId,
-      status: normalized.transientStatus,
-      text: normalized.transientText,
-      snapshot: normalized.status === "launch_started",
-      snapshotSource: "deploy_bridge_sync_restart_result"
-    });
+    if (normalized.transientStatus) {
+      await this.broadcastTransientStatus({
+        threadId: normalized.threadId,
+        status: normalized.transientStatus,
+        text: normalized.transientText,
+        snapshot: normalized.status === "launch_started",
+        snapshotSource: "deploy_bridge_sync_restart_result"
+      });
+    }
     const store = resolveDashboardChatStore(this.env);
-    const messages = store ? await store.appendMany(normalized.threadId, [normalized.message]) : [normalized.message].filter(Boolean);
+    const messages = normalized.message ? store ? await store.appendMany(normalized.threadId, [normalized.message]) : [normalized.message] : [];
     await this.broadcastThread({ threadId: normalized.threadId, messages });
   }
   async broadcastThread({ threadId, messages = null }) {
@@ -62843,25 +62845,7 @@ async function buildDeployBridgeFollowupChatMessage({ event, threadId, env, orig
       rootExecutionStarted: false,
       helperExecutionStarted: true
     },
-    message: normalizeDashboardChatMessage(
-      {
-        threadId,
-        messageId,
-        role: "system",
-        repository,
-        relatedIssue,
-        status: "sent",
-        text: buildDeployBridgeFollowupControlMessageText({
-          record: record2,
-          repository,
-          relatedIssue,
-          executionId,
-          control
-        }),
-        createdAt: record2.updatedAt || record2.createdAt
-      },
-      { threadId }
-    )
+    message: null
   };
 }
 function buildDeployBridgeFollowupControlMessage({ record: record2, executionId, repository, relatedIssue, threadId } = {}) {
@@ -63006,7 +62990,8 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
   const requestId = normalizeDashboardEventText(input.requestId || input.request_id);
   const executionId = normalizeDashboardEventText(input.executionId || input.execution_id);
   const createdAt = normalizeIsoTimestamp(input.completedAt || input.completed_at || input.createdAt || input.created_at) || (/* @__PURE__ */ new Date()).toISOString();
-  const transientStatus = status === "launch_failed" || status === "blocked" ? "failed" : "thinking";
+  const quietLaunch = status === "launch_started";
+  const transientStatus = quietLaunch ? "" : status === "launch_failed" || status === "blocked" ? "failed" : "thinking";
   const transientText = buildDeployBridgeSyncRestartResultTransientText({ status });
   const text = buildDeployBridgeSyncRestartResultMessageText({
     status,
@@ -63031,7 +63016,7 @@ function normalizeDeployBridgeSyncRestartResult(payload, { fallbackThreadId = ""
     executionId,
     transientStatus,
     transientText,
-    message: normalizeDashboardChatMessage(
+    message: quietLaunch ? null : normalizeDashboardChatMessage(
       {
         threadId,
         role: "system",
@@ -63247,26 +63232,6 @@ function buildDeployBridgeSyncRestartResultMessageText({
     lines.push("", "\u6CE8\u8A18: bridge \u5074\u3067\u8D77\u52D5\u5931\u6557\u3057\u305F\u305F\u3081\u3001\u3053\u306E deployRunId \u306E retry guard \u306F\u89E3\u653E\u3057\u307E\u3059\u3002");
   }
   return lines.join("\n");
-}
-function buildDeployBridgeFollowupControlMessageText({ record: record2, repository, relatedIssue, executionId, control } = {}) {
-  return [
-    "deploy \u5F8C bridge sync/restart \u3092\u63A5\u7D9A\u4E2D app-server bridge \u3078\u4E00\u56DE\u9650\u308A\u3067\u9001\u308A\u307E\u3057\u305F\u3002",
-    "",
-    `- repo: ${repository || "\u672A\u78BA\u8A8D"}`,
-    `- related Issue: #${relatedIssue || 741}`,
-    `- deploy run: ${record2.runId || "\u672A\u78BA\u8A8D"}`,
-    `- deploy sha: ${record2.headSha ? record2.headSha.slice(0, 12) : "\u672A\u78BA\u8A8D"}`,
-    "- \u5BFE\u8C61: repo-less Dashboard app-server bridge",
-    "- service: vtdd-dashboard-app-server-bridge-unresolved.service",
-    `- executionId: ${executionId || "\u672A\u751F\u6210"}`,
-    `- bridgeControlRequestId: ${control?.control?.requestId || "\u672A\u53D6\u5F97"}`,
-    "- authority: deploy approval \u306B\u542B\u307E\u308C\u308B\u6A19\u6E96\u5F8C\u51E6\u7406\u3067\u3059\u3002\u8FFD\u52A0 passkey \u306F\u4E0D\u8981\u3067\u3059\u3002",
-    "- persistence: GitHub Issue comment queue \u306F\u4F5C\u6210\u3057\u307E\u305B\u3093\u3002\u5B9F\u884C\u8A3C\u8DE1\u306F VPS local log / systemd journal \u5074\u306B\u6B8B\u3057\u307E\u3059\u3002",
-    "- restart guard: Dashboard \u306E pending owner messages \u306F\u4FDD\u5B58\u6E08\u307F queue \u304B\u3089 bridge reconnect \u5F8C\u306B\u518D\u9001\u3057\u307E\u3059\u3002",
-    "- runtime truth: status=bridge_control_sent, queueCommentPosted=false, rootExecutionStarted=false, helperExecutionStarted=true",
-    "",
-    "bridge \u518D\u63A5\u7D9A\u307E\u305F\u306F VPS journal \u306E before/after truth \u304C\u623B\u308B\u307E\u3067\u3001live restart \u5B8C\u4E86\u3068\u306F\u6271\u3044\u307E\u305B\u3093\u3002"
-  ].join("\n");
 }
 function buildDeployBridgeFollowupDuplicateMessage({ record: record2, repository, relatedIssue, executionId, control } = {}) {
   return [
@@ -71362,7 +71327,6 @@ function buildGitHubActionsDashboardChatMessageText(event) {
   }
   lines.push("", "\u6B21:");
   if (isDeploy && conclusion === "success") {
-    lines.push("- deploy \u5F8C bridge sync/restart \u3092\u63A5\u7D9A\u4E2D app-server bridge \u3078\u4E00\u56DE\u9650\u308A\u3067\u9001\u308A\u307E\u3059\u3002");
     lines.push("- production E2E / runtime truth \u3092\u78BA\u8A8D\u3057\u307E\u3059\u3002");
   } else if (conclusion === "failure" || conclusion === "cancelled" || conclusion === "timed_out") {
     lines.push("- deploy / Actions \u306E\u5931\u6557\u539F\u56E0\u3092\u78BA\u8A8D\u3057\u3001blocker \u3068\u6B21 action \u3092\u51FA\u3057\u307E\u3059\u3002");

--- a/worker.js
+++ b/worker.js
@@ -73887,14 +73887,15 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
 
       function renderFollowupQueue() {
         if (!followupQueueList) return;
+        const queuedItems = followupQueue.filter((item) => item && item.status === "queued");
         followupQueueList.replaceChildren();
-        followupQueueList.hidden = followupQueue.length === 0;
-        for (const item of followupQueue) {
+        followupQueueList.hidden = queuedItems.length === 0;
+        for (const item of queuedItems) {
           const mediaReferences = Array.isArray(item.mediaReferences) ? item.mediaReferences : [];
           const chip = document.createElement("div");
           chip.className = "followup-chip";
           const label = document.createElement("small");
-          label.textContent = item.status === "sent" ? "\u5DEE\u3057\u8FBC\u307F\u6E08\u307F" : "\u30AD\u30E5\u30FC\u5F85\u3061";
+          label.textContent = "\u30AD\u30E5\u30FC\u5F85\u3061";
           const text = document.createElement("span");
           text.textContent = item.text;
           chip.appendChild(label);
@@ -73904,29 +73905,27 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             media.textContent = "\u6DFB\u4ED8 " + mediaReferences.length + "\u4EF6";
             chip.appendChild(media);
           }
-          if (item.status === "queued") {
-            const actions = document.createElement("div");
-            actions.className = "followup-actions";
-            const guideButton = document.createElement("button");
-            guideButton.type = "button";
-            guideButton.dataset.followupAction = "guide";
-            guideButton.dataset.followupId = item.id;
-            guideButton.textContent = "\u8A98\u5C0E\u3059\u308B";
-            const editButton = document.createElement("button");
-            editButton.type = "button";
-            editButton.dataset.followupAction = "edit";
-            editButton.dataset.followupId = item.id;
-            editButton.textContent = "\u7DE8\u96C6\u3059\u308B";
-            const cancelButton = document.createElement("button");
-            cancelButton.type = "button";
-            cancelButton.dataset.followupAction = "cancel";
-            cancelButton.dataset.followupId = item.id;
-            cancelButton.textContent = "\u30AD\u30E3\u30F3\u30BB\u30EB";
-            actions.appendChild(guideButton);
-            actions.appendChild(editButton);
-            actions.appendChild(cancelButton);
-            chip.appendChild(actions);
-          }
+          const actions = document.createElement("div");
+          actions.className = "followup-actions";
+          const guideButton = document.createElement("button");
+          guideButton.type = "button";
+          guideButton.dataset.followupAction = "guide";
+          guideButton.dataset.followupId = item.id;
+          guideButton.textContent = "\u8A98\u5C0E\u3059\u308B";
+          const editButton = document.createElement("button");
+          editButton.type = "button";
+          editButton.dataset.followupAction = "edit";
+          editButton.dataset.followupId = item.id;
+          editButton.textContent = "\u7DE8\u96C6\u3059\u308B";
+          const cancelButton = document.createElement("button");
+          cancelButton.type = "button";
+          cancelButton.dataset.followupAction = "cancel";
+          cancelButton.dataset.followupId = item.id;
+          cancelButton.textContent = "\u30AD\u30E3\u30F3\u30BB\u30EB";
+          actions.appendChild(guideButton);
+          actions.appendChild(editButton);
+          actions.appendChild(cancelButton);
+          chip.appendChild(actions);
           followupQueueList.appendChild(chip);
         }
         updateComposerReserve();
@@ -73954,7 +73953,8 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
             mediaReferences: Array.isArray(item.mediaReferences) ? item.mediaReferences : [],
             interruption: true
           }));
-          item.status = "sent";
+          followupQueue = followupQueue.filter((queuedItem) => queuedItem.id !== item.id);
+          restoredFollowupQueueNeedsOwnerAction = false;
           persistFollowupQueue();
           renderFollowupQueue();
           return true;
@@ -73973,7 +73973,7 @@ async function renderV2DashboardPage({ runtimeOrigin, url, dashboardEventStore }
       function cancelFollowupQueueItem(itemId) {
         const before = followupQueue.length;
         restoredFollowupQueueNeedsOwnerAction = false;
-        followupQueue = followupQueue.filter((item) => item.id !== itemId || item.status === "sent");
+        followupQueue = followupQueue.filter((item) => item.id !== itemId);
         if (followupQueue.length !== before) {
           persistFollowupQueue();
           renderFollowupQueue();


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #741 の deploy 後 bridge restart で、`bridge_control_sent` / `launch_started` の中間 launch truth を通常チャットに保存しない。owner-facing chat には deploy 完了と terminal failure/completion truth だけを残す。
- Issue #816 の follow-up queue UX blocker として、送信済み follow-up を composer 上の `差し込み済み` card として残さない。composer に残すのは owner が次に操作できる未送信 queue だけにする。

## Satisfied Success Criteria

- `bridge_control_sent` follow-up message を null にし、deploy event の通常チャットから bridge restart launch 説明を削除した。
- `deploy_bridge_sync_restart_result` の `launch_started` は transient/status message と durable chat message を追加しない。`launch_failed` は従来通り failed message を残し retry guard を release する。
- follow-up queue は `status === "queued"` の item だけを表示・保存し、送信成功後は queue から remove する。`差し込み済み` label は runtime HTML から外した。

## Unsatisfied Success Criteria

- production VPS deploy -> passkey restart -> final truth readback の iPhone Butler E2E は未実施。completion/failure truth の最終表示は merge/deploy 後に確認が必要。
- production PWA で差し込み送信後に composer 上へ送信済み chip が残らないことは、merge/deploy 後の live E2E が必要。

## Non-goal violations

deploy 実行、VPS service restart 実行、credential/permission mutation、restart completion 判定の再設計、voice mode / Web Speech API / 差し込み送信 protocol の再設計は non-goal。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-741-quiet-restart-launch-truth.md
- 完了体験: Owner が deploy 後 bridge restart を承認しても、Dashboard Butler の通常チャットや composer には低情報な起動結果・送信済み差し込み card が積まれず、最終的な failure/completion truth と未送信 queue だけを読める。
- VTDD 全体で進める部分: Issue #741 の deploy 後 bridge restart owner-facing display boundary と、Issue #816 の follow-up queue 表示境界を整える。#814 voice workflow は触らない。
- 設計: Dashboard Butler owner-facing surface では success launch truth を runtime object/log に残し、通常 chat message には保存しない。follow-up queue は未送信 item のみを display/storage 対象にする。
- 仮説: owner が見たノイズは `bridge_control_sent` / `launch_started` の durable chat message と、送信済み follow-up を `sent` chip として描画する queue state が原因。
- 検証計画: worker tests で launch truth 非保存、launch_failed 保存、follow-up sent chip 非表示、generated worker sync を確認する。
- 改修見積もり: `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`, `docs/development-strategy/issue-741-quiet-restart-launch-truth.md`, `docs/development-strategy/issue-816-followup-queue-media.md`。
- 既に通っている経路: PR #829 の restart completion truth、deploy event ingest、app-server bridge control、follow-up queue mediaReferences path。
- 未確認の境界: production PWA で final completion/failure truth が戻る timing と、live composer から送信済み card が消える実機確認。
- 穴が出そうな箇所: launch truth を消しすぎると debug が難しいため runtime truth は残す。sent follow-up を残すと owner が操作不能な内部文言を再度見るため未送信 queue だけに限定する。
- PR 前に確認すること: AGENTS.md、Issue #741/#816 strategy、PR #829、reviewer request_changes、worker tests、generated worker consistency。
- 実装候補と捨てた案: 採用は success launch message null 化と sent follow-up remove。文言短縮と `差し込み済み` chip 温存は owner-facing noise を残すため捨てた。
- merge 後に通す E2E: production iPhone Dashboard Butler live E2E で deploy -> passkey restart -> final truth readback と、差し込み送信後 composer に sent chip が残らないことを検証する。
- 次の PR を増やさない理由: owner screenshot で同じ composer/chat noise regression として確認されたため、表示境界だけを同じ PR で閉じる。bridge/restart 実行と voice mode は触らない。
- 停止条件: terminal truth、failure/retry guard、authority boundary、添付つき follow-up payload を壊す必要が出たら停止する。

## Dry-run Impact Report

- Target Issue: Issue #741, Issue #816
- Implementing Success Criteria: deploy 後 bridge restart の launch truth を通常チャットに保存しない。送信済み follow-up を composer queue に残さない。
- Explicit Non-goals: deploy実行、VPS restart実行、credentials/permissions、voice mode、completion判定再設計、差し込み送信 protocol 再設計。
- Expected touched files/routes/workflows: `docs/development-strategy/issue-741-quiet-restart-launch-truth.md`, `docs/development-strategy/issue-816-followup-queue-media.md`, `src/worker/runtime.js`, `test/worker.test.js`, `worker.js`。
- Affected Issues: Issue #741 を進める。Issue #816 の queue UX blocker を部分修正する。Issue #814/#811/#637/#450 は active のまま縮小しない。
- Affected PRs: PR #829 merge 後の follow-up。PR #817 merge 後に owner が見つけた #816 UI blocker の follow-up。
- Affected workflows: worker tests、dashboard app-server bridge tests、build:worker、verify:worker、guarded checks。deploy workflow は変更しない。
- Affected runtime/operator surfaces: Dashboard Butler chat persistence、deploy event chat message、DashboardChatRoom app-server bridge result handling、Dashboard composer follow-up queue、generated worker bundle。
- What may break if we patch narrowly: launch_started だけを消すと bridge_control_sent が残る。sent follow-up remove だけだと launch message が残る。両方を owner-facing noise boundary として扱う必要がある。
- Unknowns to investigate before coding: production PWA の final completion readback timing と live sent chip disappearance は merge/deploy 後 E2E で確認する。
- Validation needed: targeted worker tests、dashboard bridge tests、build:worker、clean env verify:worker、git diff --check、PR checks。
- Stop condition: failure/retry guard や terminal truth、follow-up mediaReferences payload を壊す必要が出たら停止する。

## Execution Queue Delta

- Queue position before: Issue #741 は Now/root blocker。#816 は active queue に残る follow-up UX blocker。
- Preemption decision: ROOT: bridge restart completion truth が通常チャット/composer ノイズで読めないと Butler 経由 deploy recovery が使えないため、Issue #741 の scoped follow-up として進める。送信済み follow-up chip は #816 の既知 workflow に限って同時補正する。
- Queue delta: Issue #741 の Now/root blockerを進める。Issue #816 は部分補正するが completion とは扱わない。Next の Issue #814 は動かさない。
- Why this PR is next: owner が production screenshot で低情報 launch message と送信済み差し込み card の残存を確認したため、次の voice/diff insertion より先に recovery/chat UX を安定させる必要がある。
- Active Issues not downscoped: Active Issues は縮小しない。#816/#814/#811/#637/#450 などは未完了として remain active。

## File / Line Hypotheses

- file: `src/worker/runtime.js`; hypothesis: bridge_control_sent と launch_started を durable chat に保存し、sent follow-up を composer に描画している; risk if changed narrowly: 片方だけ残ってノイズが続く; validation: worker tests。
- file: `test/worker.test.js`; hypothesis: 既存 source guard が noisy/sent chip behavior を固定していない; risk if changed narrowly: regression が再発する; validation: updated assertions。
- file: `worker.js`; hypothesis: generated bundle drift が出る; validation: build:worker / verify:worker。

## Hypothesis Retrospective

- expected: success launch truth を message にしなければ通常チャットのノイズは止まる。sent follow-up を queue から remove すれば composer 上の `差し込み済み` card は残らない。
- actual: bridge_control_sent は message null、launch_started は transient/message なし、follow-up send success は queue item remove にした。
- mismatch: production live E2E は未実施。
- lesson: launch truth と terminal truth、未送信 queue と送信済み history を同じ owner-facing lane に混ぜない。
- should become RAG candidate: Issue #741/#816 owner-facing noise boundary。

## Verification Evidence

- Unit: `node --test test/worker.test.js --test-name-pattern "followup|deploy bridge|restart launch|GitHub Actions deploy completion"`: PASS。
- Unit: `node --test test/dashboard-app-server-bridge.test.js --test-name-pattern "deploy restart|bridge sync|local helper|wakeup"`: PASS。
- Unit: `node --test test/active-issue-execution-queue.test.js`: PASS。
- Integration: `npm run build:worker`: PASS。
- Integration: `env -u VTDD_GATEWAY_BEARER_TOKEN -u VTDD_CREDENTIALS_MANIFEST -u VTDD_VPS_RUNNER_CREDENTIALS_MANIFEST npm run verify:worker`: PASS。
- Static: `git diff --check`: PASS。
- E2E: Not run. production Dashboard Butler live E2E は merge/deploy 後に必要。
- Manual: 通常 env の `npm run verify:worker` は既存 gateway bearer vault bootstrap tests が実 VPS token env を拾って FAIL するため、clean env で PASS を確認した。
- Evidence path/link: `docs/development-strategy/issue-741-quiet-restart-launch-truth.md`, `docs/development-strategy/issue-816-followup-queue-media.md`

## Butler Completion Contract

- Primary owner surface: Dashboard Butler
- Fallback surface: mac Codex は実装・検証用 fallback。主経路ではない。
- Owner goal: deploy 後 bridge restart の中間起動結果と送信済み差し込み card を毎回読まされず、必要な final truth と未送信 queue だけを読めること。
- Butler entrypoint: Dashboard Butler の通常チャットと deploy/passkey continuation。新しい raw API 入力は要求しない。
- Dashboard Butler natural-language path: Dashboard Butler の自然文 / 通常チャット entrypoint から deploy 後の状態確認と差し込み queue 操作に到達する経路を前提にする。
- Action Schema exposure: Custom GPT Action Schema は未変更。主経路とは扱わない。
- Runtime path: GitHub Actions deploy event -> Worker event ingest -> deployBridgeFollowup runtimeTruth -> app-server bridge control/result -> DashboardChatRoom persistence filter。follow-up queue は Dashboard composer -> owner_message WebSocket payload。
- Runner/runtime truth: bridge_control_sent と launch_started は runtime object/log には残るが通常 chat message には保存しない。launch_failed/blocked は failure truth として保存する。
- Authority boundary: 未変更。deploy/restart 実行は passkey 承認が必要。この PR はコードとテストのみで、高リスク外部効果は実行しない。
- E2E evidence: 未実施。merge/deploy 後に iPhone Dashboard Butler で同じ flow を確認する必要がある。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。この PR 作成時点では deploy しない。merge 後に owner/passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate、Authority Boundary、Drift Stop Protocol、開発前作戦図 Gate、Execution Queue Contract、Issue #741/#816 scope。

## Out-of-scope but NOT implemented

- production deploy/restart 実行。Issue closure。voice mode と差し込み送信 protocol 再設計。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #741, Issue #816
- Execution ID: mac-codex-issue-741-quiet-restart-launch-truth-2026-06-08
- Goal: Issue #741 deploy 後 bridge restart の中間 launch truth と Issue #816 sent follow-up chip を owner-facing surface に残さない
