### PR TITLE
Issue #741 VPS approval continuation truth

### DIFF
--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -879,19 +879,49 @@ export function renderPasskeyOperatorPage(input = {}) {
           throw responseError(continueBody, "VPS helper queue handoff failed");
         }
         const runtimeTruth = continueBody?.execution?.runtimeTruth || {};
-        if (continueBody?.execution?.status !== "queued_for_vps_helper_execution") {
+        if (!isVpsHelperQueueHandoffAccepted(continueBody)) {
           const executionStatus = continueBody?.execution?.status || "blocked";
-          const errorText = continueBody?.error || continueBody?.execution?.runtimeTruth?.status || executionStatus;
+          const issues = Array.isArray(continueBody?.execution?.runtimeTruth?.issues)
+            ? continueBody.execution.runtimeTruth.issues
+            : Array.isArray(continueBody?.issues)
+              ? continueBody.issues
+              : [];
+          const errorText =
+            continueBody?.error ||
+            continueBody?.reason ||
+            continueBody?.execution?.runtimeTruth?.status ||
+            continueBody?.execution?.runtimeTruth?.reason ||
+            continueBody?.execution?.queue?.status ||
+            executionStatus;
           const nextAction = continueBody?.execution?.runtimeTruth?.nextAction || continueBody?.runtimeTruth?.nextAction || "";
           throw new Error(
             "VPS helper queue handoff blocked. "
             + errorText
+            + (issues.length > 0 ? ". issues: " + issues.join("; ") : "")
             + (nextAction ? ". next action: " + nextAction : "")
           );
         }
-        setApproveOutput("VPS helper queue へ渡しました。Dashboard Butler と通知で進捗を確認してください。", {
+        setApproveOutput(buildVpsHelperQueueAcceptedText(continueBody), {
           show: shouldShowApproveOutput("status")
         });
+      }
+
+      function isVpsHelperQueueHandoffAccepted(body) {
+        const executionStatus = String(body?.execution?.status || "");
+        const queueStatus = String(body?.execution?.queue?.status || "");
+        const runtimeStatus = String(body?.execution?.runtimeTruth?.status || body?.runtimeTruth?.status || "");
+        if (executionStatus === "queued_for_vps_helper_execution" || executionStatus === "sent_to_bridge") return true;
+        if (queueStatus === "sent_to_bridge" || queueStatus === "queued") return true;
+        if (runtimeStatus === "vps_local_helper_queue_control_sent" || runtimeStatus === "vps_local_helper_queue_queued") return true;
+        return false;
+      }
+
+      function buildVpsHelperQueueAcceptedText(body) {
+        const runtimeStatus = String(body?.execution?.runtimeTruth?.status || body?.runtimeTruth?.status || "");
+        if (runtimeStatus === "vps_local_helper_queue_control_sent") {
+          return "VPS helper queue への引き渡しを app-server bridge へ送りました。Dashboard Butler と通知で local queue の保存結果を確認してください。";
+        }
+        return "VPS helper queue へ渡しました。Dashboard Butler と通知で進捗を確認してください。";
       }
 
       if (copyApprovalGrantButton) {

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -911,8 +911,8 @@ export function renderPasskeyOperatorPage(input = {}) {
         const queueStatus = String(body?.execution?.queue?.status || "");
         const runtimeStatus = String(body?.execution?.runtimeTruth?.status || body?.runtimeTruth?.status || "");
         if (executionStatus === "queued_for_vps_helper_execution" || executionStatus === "sent_to_bridge") return true;
-        if (queueStatus === "sent_to_bridge" || queueStatus === "queued") return true;
-        if (runtimeStatus === "vps_local_helper_queue_control_sent" || runtimeStatus === "vps_local_helper_queue_queued") return true;
+        if (queueStatus === "sent_to_bridge" && runtimeStatus === "vps_local_helper_queue_control_sent") return true;
+        if (runtimeStatus === "vps_local_helper_queue_control_sent" && executionStatus !== "blocked") return true;
         return false;
       }
 

--- a/src/core/passkey-operator-page.js
+++ b/src/core/passkey-operator-page.js
@@ -879,7 +879,7 @@ export function renderPasskeyOperatorPage(input = {}) {
           throw responseError(continueBody, "VPS helper queue handoff failed");
         }
         const runtimeTruth = continueBody?.execution?.runtimeTruth || {};
-        if (!isVpsHelperQueueHandoffAccepted(continueBody)) {
+        if (!isVpsHelperQueueHandoffLaunchAcknowledged(continueBody)) {
           const executionStatus = continueBody?.execution?.status || "blocked";
           const issues = Array.isArray(continueBody?.execution?.runtimeTruth?.issues)
             ? continueBody.execution.runtimeTruth.issues
@@ -901,27 +901,29 @@ export function renderPasskeyOperatorPage(input = {}) {
             + (nextAction ? ". next action: " + nextAction : "")
           );
         }
-        setApproveOutput(buildVpsHelperQueueAcceptedText(continueBody), {
+        setApproveOutput(buildVpsHelperQueueLaunchAcknowledgedText(continueBody), {
           show: shouldShowApproveOutput("status")
         });
       }
 
-      function isVpsHelperQueueHandoffAccepted(body) {
+      function isVpsHelperQueueHandoffLaunchAcknowledged(body) {
         const executionStatus = String(body?.execution?.status || "");
         const queueStatus = String(body?.execution?.queue?.status || "");
         const runtimeStatus = String(body?.execution?.runtimeTruth?.status || body?.runtimeTruth?.status || "");
-        if (executionStatus === "queued_for_vps_helper_execution" || executionStatus === "sent_to_bridge") return true;
+        if (executionStatus === "queued_for_vps_helper_execution") return true;
+        if (runtimeStatus !== "vps_local_helper_queue_control_sent") return false;
+        if (executionStatus === "sent_to_bridge") return true;
         if (queueStatus === "sent_to_bridge" && runtimeStatus === "vps_local_helper_queue_control_sent") return true;
-        if (runtimeStatus === "vps_local_helper_queue_control_sent" && executionStatus !== "blocked") return true;
+        if (executionStatus !== "" && executionStatus !== "blocked") return true;
         return false;
       }
 
-      function buildVpsHelperQueueAcceptedText(body) {
+      function buildVpsHelperQueueLaunchAcknowledgedText(body) {
         const runtimeStatus = String(body?.execution?.runtimeTruth?.status || body?.runtimeTruth?.status || "");
         if (runtimeStatus === "vps_local_helper_queue_control_sent") {
-          return "VPS helper queue への引き渡しを app-server bridge へ送りました。Dashboard Butler と通知で local queue の保存結果を確認してください。";
+          return "VPS helper queue への引き渡し要求を app-server bridge へ送りました。これは queue 保存完了ではありません。Dashboard Butler と通知で local queue の保存結果を確認してください。";
         }
-        return "VPS helper queue へ渡しました。Dashboard Butler と通知で進捗を確認してください。";
+        return "VPS helper queue handoff の起動応答を受け取りました。これは完了結果ではありません。Dashboard Butler と通知で local queue の保存結果を確認してください。";
       }
 
       if (copyApprovalGrantButton) {

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -538,6 +538,10 @@ test("passkey operator page focuses VPS runner admin mode on real approval only"
   assert.equal(html.includes('id="action-type-input" value="destructive"'), true);
   assert.equal(html.includes('id="risk-kind-input" value="vps_runner_admin"'), true);
   assert.equal(html.includes("文字列としての passkey は承認ではありません"), true);
+  assert.equal(html.includes("function isVpsHelperQueueHandoffAccepted(body)"), true);
+  assert.equal(html.includes('executionStatus === "sent_to_bridge"'), true);
+  assert.equal(html.includes('runtimeStatus === "vps_local_helper_queue_control_sent"'), true);
+  assert.equal(html.includes("VPS helper queue handoff did not queue"), false);
 });
 
 test("passkey operator page supports gateway bearer vault bootstrap mode", () => {

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -538,12 +538,16 @@ test("passkey operator page focuses VPS runner admin mode on real approval only"
   assert.equal(html.includes('id="action-type-input" value="destructive"'), true);
   assert.equal(html.includes('id="risk-kind-input" value="vps_runner_admin"'), true);
   assert.equal(html.includes("文字列としての passkey は承認ではありません"), true);
-  assert.equal(html.includes("function isVpsHelperQueueHandoffAccepted(body)"), true);
+  assert.equal(html.includes("function isVpsHelperQueueHandoffLaunchAcknowledged(body)"), true);
   assert.equal(html.includes('executionStatus === "sent_to_bridge"'), true);
   assert.equal(html.includes('runtimeStatus === "vps_local_helper_queue_control_sent"'), true);
+  assert.equal(html.includes('runtimeStatus !== "vps_local_helper_queue_control_sent"'), true);
+  assert.equal(html.includes('executionStatus === "queued_for_vps_helper_execution" || executionStatus === "sent_to_bridge"'), false);
   assert.equal(html.includes('queueStatus === "queued"'), false);
   assert.equal(html.includes('runtimeStatus === "vps_local_helper_queue_queued"'), false);
-  assert.equal(html.includes('executionStatus !== "blocked"'), true);
+  assert.equal(html.includes('executionStatus !== "" && executionStatus !== "blocked"'), true);
+  assert.equal(html.includes("これは queue 保存完了ではありません"), true);
+  assert.equal(html.includes("これは完了結果ではありません"), true);
   assert.equal(html.includes("VPS helper queue handoff did not queue"), false);
 });
 

--- a/test/passkey-operator-page.test.js
+++ b/test/passkey-operator-page.test.js
@@ -541,6 +541,9 @@ test("passkey operator page focuses VPS runner admin mode on real approval only"
   assert.equal(html.includes("function isVpsHelperQueueHandoffAccepted(body)"), true);
   assert.equal(html.includes('executionStatus === "sent_to_bridge"'), true);
   assert.equal(html.includes('runtimeStatus === "vps_local_helper_queue_control_sent"'), true);
+  assert.equal(html.includes('queueStatus === "queued"'), false);
+  assert.equal(html.includes('runtimeStatus === "vps_local_helper_queue_queued"'), false);
+  assert.equal(html.includes('executionStatus !== "blocked"'), true);
   assert.equal(html.includes("VPS helper queue handoff did not queue"), false);
 });
 

--- a/worker.js
+++ b/worker.js
@@ -28101,19 +28101,49 @@ function renderPasskeyOperatorPage(input = {}) {
           throw responseError(continueBody, "VPS helper queue handoff failed");
         }
         const runtimeTruth = continueBody?.execution?.runtimeTruth || {};
-        if (continueBody?.execution?.status !== "queued_for_vps_helper_execution") {
+        if (!isVpsHelperQueueHandoffAccepted(continueBody)) {
           const executionStatus = continueBody?.execution?.status || "blocked";
-          const errorText = continueBody?.error || continueBody?.execution?.runtimeTruth?.status || executionStatus;
+          const issues = Array.isArray(continueBody?.execution?.runtimeTruth?.issues)
+            ? continueBody.execution.runtimeTruth.issues
+            : Array.isArray(continueBody?.issues)
+              ? continueBody.issues
+              : [];
+          const errorText =
+            continueBody?.error ||
+            continueBody?.reason ||
+            continueBody?.execution?.runtimeTruth?.status ||
+            continueBody?.execution?.runtimeTruth?.reason ||
+            continueBody?.execution?.queue?.status ||
+            executionStatus;
           const nextAction = continueBody?.execution?.runtimeTruth?.nextAction || continueBody?.runtimeTruth?.nextAction || "";
           throw new Error(
             "VPS helper queue handoff blocked. "
             + errorText
+            + (issues.length > 0 ? ". issues: " + issues.join("; ") : "")
             + (nextAction ? ". next action: " + nextAction : "")
           );
         }
-        setApproveOutput("VPS helper queue \u3078\u6E21\u3057\u307E\u3057\u305F\u3002Dashboard Butler \u3068\u901A\u77E5\u3067\u9032\u6357\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002", {
+        setApproveOutput(buildVpsHelperQueueAcceptedText(continueBody), {
           show: shouldShowApproveOutput("status")
         });
+      }
+
+      function isVpsHelperQueueHandoffAccepted(body) {
+        const executionStatus = String(body?.execution?.status || "");
+        const queueStatus = String(body?.execution?.queue?.status || "");
+        const runtimeStatus = String(body?.execution?.runtimeTruth?.status || body?.runtimeTruth?.status || "");
+        if (executionStatus === "queued_for_vps_helper_execution" || executionStatus === "sent_to_bridge") return true;
+        if (queueStatus === "sent_to_bridge" || queueStatus === "queued") return true;
+        if (runtimeStatus === "vps_local_helper_queue_control_sent" || runtimeStatus === "vps_local_helper_queue_queued") return true;
+        return false;
+      }
+
+      function buildVpsHelperQueueAcceptedText(body) {
+        const runtimeStatus = String(body?.execution?.runtimeTruth?.status || body?.runtimeTruth?.status || "");
+        if (runtimeStatus === "vps_local_helper_queue_control_sent") {
+          return "VPS helper queue \u3078\u306E\u5F15\u304D\u6E21\u3057\u3092 app-server bridge \u3078\u9001\u308A\u307E\u3057\u305F\u3002Dashboard Butler \u3068\u901A\u77E5\u3067 local queue \u306E\u4FDD\u5B58\u7D50\u679C\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002";
+        }
+        return "VPS helper queue \u3078\u6E21\u3057\u307E\u3057\u305F\u3002Dashboard Butler \u3068\u901A\u77E5\u3067\u9032\u6357\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002";
       }
 
       if (copyApprovalGrantButton) {

--- a/worker.js
+++ b/worker.js
@@ -28133,8 +28133,8 @@ function renderPasskeyOperatorPage(input = {}) {
         const queueStatus = String(body?.execution?.queue?.status || "");
         const runtimeStatus = String(body?.execution?.runtimeTruth?.status || body?.runtimeTruth?.status || "");
         if (executionStatus === "queued_for_vps_helper_execution" || executionStatus === "sent_to_bridge") return true;
-        if (queueStatus === "sent_to_bridge" || queueStatus === "queued") return true;
-        if (runtimeStatus === "vps_local_helper_queue_control_sent" || runtimeStatus === "vps_local_helper_queue_queued") return true;
+        if (queueStatus === "sent_to_bridge" && runtimeStatus === "vps_local_helper_queue_control_sent") return true;
+        if (runtimeStatus === "vps_local_helper_queue_control_sent" && executionStatus !== "blocked") return true;
         return false;
       }
 

--- a/worker.js
+++ b/worker.js
@@ -28101,7 +28101,7 @@ function renderPasskeyOperatorPage(input = {}) {
           throw responseError(continueBody, "VPS helper queue handoff failed");
         }
         const runtimeTruth = continueBody?.execution?.runtimeTruth || {};
-        if (!isVpsHelperQueueHandoffAccepted(continueBody)) {
+        if (!isVpsHelperQueueHandoffLaunchAcknowledged(continueBody)) {
           const executionStatus = continueBody?.execution?.status || "blocked";
           const issues = Array.isArray(continueBody?.execution?.runtimeTruth?.issues)
             ? continueBody.execution.runtimeTruth.issues
@@ -28123,27 +28123,29 @@ function renderPasskeyOperatorPage(input = {}) {
             + (nextAction ? ". next action: " + nextAction : "")
           );
         }
-        setApproveOutput(buildVpsHelperQueueAcceptedText(continueBody), {
+        setApproveOutput(buildVpsHelperQueueLaunchAcknowledgedText(continueBody), {
           show: shouldShowApproveOutput("status")
         });
       }
 
-      function isVpsHelperQueueHandoffAccepted(body) {
+      function isVpsHelperQueueHandoffLaunchAcknowledged(body) {
         const executionStatus = String(body?.execution?.status || "");
         const queueStatus = String(body?.execution?.queue?.status || "");
         const runtimeStatus = String(body?.execution?.runtimeTruth?.status || body?.runtimeTruth?.status || "");
-        if (executionStatus === "queued_for_vps_helper_execution" || executionStatus === "sent_to_bridge") return true;
+        if (executionStatus === "queued_for_vps_helper_execution") return true;
+        if (runtimeStatus !== "vps_local_helper_queue_control_sent") return false;
+        if (executionStatus === "sent_to_bridge") return true;
         if (queueStatus === "sent_to_bridge" && runtimeStatus === "vps_local_helper_queue_control_sent") return true;
-        if (runtimeStatus === "vps_local_helper_queue_control_sent" && executionStatus !== "blocked") return true;
+        if (executionStatus !== "" && executionStatus !== "blocked") return true;
         return false;
       }
 
-      function buildVpsHelperQueueAcceptedText(body) {
+      function buildVpsHelperQueueLaunchAcknowledgedText(body) {
         const runtimeStatus = String(body?.execution?.runtimeTruth?.status || body?.runtimeTruth?.status || "");
         if (runtimeStatus === "vps_local_helper_queue_control_sent") {
-          return "VPS helper queue \u3078\u306E\u5F15\u304D\u6E21\u3057\u3092 app-server bridge \u3078\u9001\u308A\u307E\u3057\u305F\u3002Dashboard Butler \u3068\u901A\u77E5\u3067 local queue \u306E\u4FDD\u5B58\u7D50\u679C\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002";
+          return "VPS helper queue \u3078\u306E\u5F15\u304D\u6E21\u3057\u8981\u6C42\u3092 app-server bridge \u3078\u9001\u308A\u307E\u3057\u305F\u3002\u3053\u308C\u306F queue \u4FDD\u5B58\u5B8C\u4E86\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002Dashboard Butler \u3068\u901A\u77E5\u3067 local queue \u306E\u4FDD\u5B58\u7D50\u679C\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002";
         }
-        return "VPS helper queue \u3078\u6E21\u3057\u307E\u3057\u305F\u3002Dashboard Butler \u3068\u901A\u77E5\u3067\u9032\u6357\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002";
+        return "VPS helper queue handoff \u306E\u8D77\u52D5\u5FDC\u7B54\u3092\u53D7\u3051\u53D6\u308A\u307E\u3057\u305F\u3002\u3053\u308C\u306F\u5B8C\u4E86\u7D50\u679C\u3067\u306F\u3042\u308A\u307E\u305B\u3093\u3002Dashboard Butler \u3068\u901A\u77E5\u3067 local queue \u306E\u4FDD\u5B58\u7D50\u679C\u3092\u78BA\u8A8D\u3057\u3066\u304F\u3060\u3055\u3044\u3002";
       }
 
       if (copyApprovalGrantButton) {


### PR DESCRIPTION
## This PR satisfies Intent

- Issue #741 の VPS Runner Admin passkey operator continuation で、local helper queue 主経路の `sent_to_bridge` + `vps_local_helper_queue_control_sent` を queue 保存完了ではなく handoff launch acknowledged truth として扱う。
- `VPS helper queue handoff did not queue. unknown` のような古い/曖昧な表示ではなく、blocked 時は runtime truth / reason / issues / nextAction を operator に出す。

## Satisfied Success Criteria

- passkey operator の continuation 判定を `queued_for_vps_helper_execution` 固定から、`sent_to_bridge` 単体ではなく runtime truth `vps_local_helper_queue_control_sent` と一致する handoff launch acknowledged truth も受け入れる判定へ変更した。
- owner-facing copy は queue 保存完了や helper 完了ではなく、app-server bridge へ引き渡し要求を送った段階であることを明記した。
- blocked 時の operator error は `error` / `reason` / `runtimeTruth.status` / `runtimeTruth.reason` / `queue.status` / `issues` / `nextAction` を拾い、`unknown` に落ちにくくした。
- generated `worker.js` を同期した。

## Unsatisfied Success Criteria

- production VPS live E2E は未実施。merge/deploy 後に passkey operator URL を再発行し、承認後に `sent_to_bridge` または明示的 blocked reason が表示されることを確認する必要がある。
- queue が実際に VPS local pending/state/log へ保存され、runner が pickup する terminal truth はこの PR だけでは未完了。

## Non-goal violations

deploy 実行、VPS service restart 実行、root/helper 実行、credential/permission mutation、watchdog timer install、Issue closure は non-goal。

## 開発前作戦図

- 作戦図 evidence: docs/development-strategy/issue-741-vps-approval-continuation.md
- 完了体験: Owner が Dashboard Butler から開いた VPS Runner Admin passkey operator で承認したあと、operator は bridge handoff launch acknowledged truth を起動応答として扱い、queue 保存完了とは誤読させず、失敗時も unknown ではなく原因と次 action を表示する。
- VTDD 全体で進める部分: Issue #741 の deploy/restart/recovery path のうち、passkey approval continuation の owner-facing truth を安定させる。VPS 実行そのものは行わない。
- 設計: Dashboard Butler owner-facing surface の passkey operator JS で、Worker の local helper queue transport が返す `sent_to_bridge` を runtime truth `vps_local_helper_queue_control_sent` とセットの場合だけ launch acknowledged として扱う。blocked は reason/issue/nextAction を出す。
- 仮説: 原因は現行 operator が `queued_for_vps_helper_execution` だけを成功扱いすること。local helper queue を app-server bridge に渡した `sent_to_bridge` 系 truth を failure と誤判定し、blocked detail が薄い場合に unknown 表示へ落ちる。
- 検証計画: passkey operator source guard、Worker VPS continuation targeted tests、active issue queue test、build:worker、clean env verify:worker、git diff --check を通す。
- 改修見積もり: `src/core/passkey-operator-page.js` の continuation launch/error判定、`test/passkey-operator-page.test.js` の source guard、generated `worker.js`。
- 既に通っている経路: proposal 作成、approval URL 表示、passkey approval、Dashboard chat continuation POST、Worker 側 continuation intent / blocked visibility tests。
- 未確認の境界: production app-server bridge が接続中か、VPS local queue 保存結果が Dashboard に戻るか、runner pickup / terminal truth まで進むか。
- 穴が出そうな箇所: 判定を広げすぎると blocked や queue 未保存を成功扱いする。今回は `sent_to_bridge` 単体では通さず、runtime truth `vps_local_helper_queue_control_sent` と一致する起動応答だけに限定する。
- PR 前に確認すること: AGENTS.md、Issue #741 strategy、operator screenshot の error、current `main`、targeted tests、generated worker consistency。
- 実装候補と捨てた案: 採用は launch acknowledged helper と blocked detail extraction。捨てた案は operator 文言だけの変更で、runtime truth mismatch を残すため不採用。
- merge 後に通す E2E: production iPhone Dashboard Butler live E2E で新しい VPS Runner Admin operator URL を開き、passkey 承認後に launch acknowledged text または明示的 blocked reason が出ることを検証する。
- 次の PR を増やさない理由: unknown 表示の原因は operator launch/error 判定の同一箇所にあり、ここを狭く直せば次の live E2E で remaining blocker を正しく読める。
- 停止条件: approval scope validation、Dashboard auth continuation、terminal helper result の実行が必要になった場合はこの PR では止め、別の passkey/live E2E 境界として扱う。

## Dry-run Impact Report

- Target Issue: Issue #741
- Implementing Success Criteria: passkey operator continuation が local helper queue bridge handoff launch truth を queue completion と分けて扱い、blocked 時に unknown ではなく reason を表示する。
- Explicit Non-goals: deploy、VPS restart、root/helper execution、credentials、permissions、watchdog/timer install、Issue closure。
- Expected touched files/routes/workflows: `src/core/passkey-operator-page.js`, `test/passkey-operator-page.test.js`, `worker.js`。
- Affected Issues: Issue #741 を進める。Issue #816/#814/#811/#637/#450 は active のまま縮小しない。
- Affected PRs: PR #830 merge/deploy 後の #741 continuation follow-up。新規 PR として作成し、merged PR branch には push しない。
- Affected workflows: passkey operator page rendering、VPS runner admin auto continuation、worker bundle generation、guarded checks。
- Affected runtime/operator surfaces: `/v2/approval/passkey/operator` の VPS Runner Admin mode、Dashboard Butler passkey continuation result display。
- What may break if we patch narrowly: `sent_to_bridge` と `vps_local_helper_queue_control_sent` の起動応答を拾わないと false blocked になる。blocked detail を拾わないと unknown が残る。
- Unknowns to investigate before coding: production bridge socket / local queue / runner pickup は live E2E まで未確認。
- Validation needed: passkey operator tests、Worker VPS continuation tests、active queue tests、build:worker、clean env verify:worker、git diff --check、PR checks。
- Stop condition: high-risk external effect が必要になった場合、または approval scope validation が壊れている場合。

## Execution Queue Delta

- Queue position before: Issue #741 は Now/root blocker。#816 の差し込み card blocker は解消確認済み。
- Preemption decision: ROOT: passkey approval continuation が unknown のままだと VPS recovery/deploy follow-up を Butler 経由で信頼できない。
- Queue delta: Issue #741 の continuation blocker を進める。`Now` は Issue #741 のまま維持し、Issue #816/#814 は Next/Queue に残す。
- Why this PR is next: owner が operator screenshot で `VPS helper queue handoff did not queue. unknown` を確認し、これは deploy/recovery foundation の blocker だから。
- Active Issues not downscoped: Active Issues は縮小しない。#816/#814/#811/#637/#450 は未完了として remain active。

## File / Line Hypotheses

- file: `src/core/passkey-operator-page.js`; hypothesis: continuation check が `queued_for_vps_helper_execution` 固定で local helper queue bridge handoff launch truth とズレる; validation: source guard and worker bundle.
- file: `test/passkey-operator-page.test.js`; hypothesis: operator JS の launch acknowledged statuses が regression test で固定されていない; validation: source guard.
- file: `worker.js`; hypothesis: generated bundle drift が出る; validation: build:worker / check-generated-worker / verify:worker.

## Hypothesis Retrospective

- expected: operator が `sent_to_bridge` + `vps_local_helper_queue_control_sent` を launch acknowledged として扱えば、false blocked/unknown を避けられる。
- actual: `isVpsHelperQueueHandoffLaunchAcknowledged()` を追加し、blocked detail extraction も広げた。
- mismatch: production live E2E は未実施。
- lesson: local queue 主経路では queue 保存完了前の bridge control sent を launch truth として扱うが、queue 保存完了 / runner pickup / terminal truth とは明確に分けて表示する。
- should become RAG candidate: Issue #741 passkey continuation launch acknowledged status boundary.

## Verification Evidence

- Unit: `node --test test/passkey-operator-page.test.js --test-name-pattern "VPS runner admin|vps"`: PASS。
- Unit: `node --test test/worker.test.js --test-name-pattern "VPS passkey operator continuation|approvalGrantId and vpsProposalId|blocked VPS continuation|VPS privileged maintenance|VPS runner admin passkey operator|VPS maintenance approval"`: PASS。
- Unit: `node --test test/active-issue-execution-queue.test.js`: PASS。
- Integration: `npm run build:worker`: PASS。
- Integration: `env -u VTDD_GATEWAY_BEARER_TOKEN -u VTDD_CREDENTIALS_MANIFEST -u VTDD_VPS_RUNNER_CREDENTIALS_MANIFEST npm run verify:worker`: PASS。
- Static: `git diff --check`: PASS。
- Review response: request_changes の重要指摘に対応し、`queue.status === "queued"` 単独と `vps_local_helper_queue_queued` 単独では launch acknowledged にしないよう狭めた。
- Review response: Gemini request_changes の `sent_to_bridge` ambiguity に対応し、`sent_to_bridge` 単体では通さず、`runtimeTruth.status === "vps_local_helper_queue_control_sent"` と一致する場合だけ launch acknowledged として扱うよう狭めた。owner-facing copy も「queue 保存完了ではありません」「完了結果ではありません」と明記した。
- E2E: Not run. production Dashboard Butler live E2E は merge/deploy 後に必要。
- Evidence path/link: docs/development-strategy/issue-741-vps-approval-continuation.md

## Butler Completion Contract

- Primary owner surface: Dashboard Butler
- Fallback surface: mac Codex は実装・検証用 fallback。主経路ではない。
- Owner goal: passkey 承認後に operator が unknown で止まらず、bridge handoff launch acknowledged または明示的 blocked reason を読めること。
- Butler entrypoint: Dashboard Butler の自然文から VPS Runner Admin operator URL を開き、passkey 承認後に同じ thread へ continuation する。
- Dashboard Butler natural-language path: Dashboard Butler 通常チャットの recovery/deploy follow-up intent が approval URL に到達し、承認後の result を同じ owner-facing path に戻す。
- Action Schema exposure: Custom GPT Action Schema は未変更。主経路とは扱わない。
- Runtime path: Dashboard Butler -> passkey operator -> `/v2/dashboard/chat/messages` continuation -> Worker VPS maintenance flow -> app-server bridge local helper queue control。
- Runner/runtime truth: `sent_to_bridge` / `vps_local_helper_queue_control_sent` は launch truth。VPS runner pickup / completed / failed は merge/deploy 後 E2E で確認が必要。
- Authority boundary: 未変更。passkey approval は high-risk handoff に必要。この PR はコードとテストのみで外部 high-risk action は実行しない。
- E2E evidence: 未実施。merge/deploy 後に iPhone Dashboard Butler で operator continuation を確認する必要がある。
- Completion status: incomplete

## Surface Update Checklist

- Cloudflare deploy: 不要。この PR 作成時点では deploy しない。merge 後に owner/passkey approval が必要。
- Custom GPT Action Schema update: 不要。
- Custom GPT Instructions update: 不要。
- iPhone Butler live E2E: 未実施。merge/deploy 後に必要。

## Related Constitution Rules

- AGENTS.md Butler Completion Gate、Authority Boundary、Drift Stop Protocol、開発前作戦図 Gate、Execution Queue Contract、Issue #741 scope。

## Out-of-scope but NOT implemented

- VPS restart 実行、root/helper execution、watchdog timer install、Issue closure、production deploy。

## Extra changes (if any)

None.

<!-- VTDD metadata -->
- Issue: Issue #741
- Execution ID: mac-codex-issue-741-vps-approval-continuation-2026-06-08
- Goal: Issue #741 VPS Runner Admin passkey operator continuation の launch/blocked truth を修正する
